### PR TITLE
feat(i18n): translate practice/competition form options and add creatable club select

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -56,6 +56,21 @@ export async function PATCH(request: NextRequest) {
 			return NextResponse.json({ error: 'Invalid locale. Must be "no" or "en".' }, { status: 400 });
 		}
 
+		// Normalize club: trim whitespace; treat empty string as null. Cap at
+		// 100 chars — the longest Norwegian club name is ~43 chars, so this
+		// gives international users plenty of room without enabling abuse.
+		let normalizedClub: string | null | undefined = club;
+		if (club !== undefined && club !== null) {
+			if (typeof club !== 'string') {
+				return NextResponse.json({ error: 'Invalid club. Must be a string.' }, { status: 400 });
+			}
+			const trimmed = club.trim();
+			if (trimmed.length > 100) {
+				return NextResponse.json({ error: 'Club name too long. Max 100 characters.' }, { status: 400 });
+			}
+			normalizedClub = trimmed === '' ? null : trimmed;
+		}
+
 		// Validate image if provided
 		if (image !== undefined && image !== null) {
 			// Check if it's a valid base64 image or external URL
@@ -76,7 +91,7 @@ export async function PATCH(request: NextRequest) {
 		const updatedUser = await prisma.user.update({
 			where: { id: user.id },
 			data: {
-				...(club !== undefined && { club }),
+				...(club !== undefined && { club: normalizedClub }),
 				...(name !== undefined && { name }),
 				...(image !== undefined && { image }),
 				...(skytternr !== undefined && { skytternr }),

--- a/components/Competitions/CompetitionFormInfoStep.tsx
+++ b/components/Competitions/CompetitionFormInfoStep.tsx
@@ -7,7 +7,7 @@ import type { PracticeCategory, WeatherCondition } from '@/lib/prismaEnums';
 import { Environment } from '@/lib/prismaEnums';
 import { DateInput, Input, Select } from '@/components';
 import { getArrowsOptions, getBowOptions, getEnvironmentOptions, getPracticeCategoryOptions } from '@/lib/formUtils';
-import { WEATHER_OPTIONS } from './CompetitionFormModal.types';
+import { getWeatherOptions } from './CompetitionFormModal.types';
 import { useTranslation } from '@/context/LanguageProvider';
 
 interface InfoStepProps {
@@ -60,10 +60,11 @@ export const CompetitionFormInfoStep: React.FC<InfoStepProps> = ({
 	onDeleteRequest,
 }) => {
 	const { t } = useTranslation();
-	const environmentOptions = getEnvironmentOptions();
-	const practiceCategoryOptions = getPracticeCategoryOptions();
-	const bowOptions = getBowOptions(bows);
-	const arrowsOptions = getArrowsOptions(arrows);
+	const environmentOptions = getEnvironmentOptions(t);
+	const practiceCategoryOptions = getPracticeCategoryOptions(t);
+	const bowOptions = getBowOptions(bows, t);
+	const arrowsOptions = getArrowsOptions(arrows, t);
+	const weatherOptions = getWeatherOptions(t);
 
 	return (
 		<div className={styles.stepContent}>
@@ -118,7 +119,7 @@ export const CompetitionFormInfoStep: React.FC<InfoStepProps> = ({
 				<div className={styles.weatherSection}>
 					<div className={styles.weatherLabel}>{t['form.weather']}</div>
 					<div className={styles.weatherChips}>
-						{WEATHER_OPTIONS.map((opt) => {
+						{weatherOptions.map((opt) => {
 							const active = weather.includes(opt.value);
 							return (
 								<button

--- a/components/Competitions/CompetitionFormModal.types.ts
+++ b/components/Competitions/CompetitionFormModal.types.ts
@@ -1,21 +1,28 @@
 import type { PracticeCategory, WeatherCondition } from '@/lib/prismaEnums';
 import { Environment } from '@/lib/prismaEnums';
 import { TARGET_TYPE_OPTIONS } from '@/lib/Contants';
+import type { TranslationKeys } from '@/lib/i18n/types';
 
 export const TOTAL_STEPS = 4;
-export const STEP_LABELS = ['Info', 'Runder', 'Resultat', 'Refleksjon'];
 
-export const WEATHER_OPTIONS: { value: WeatherCondition; label: string }[] = [
-	{ value: 'SUN', label: '☀️ Sol' },
-	{ value: 'CLOUDED', label: '⛅ Skyet' },
-	{ value: 'CLEAR', label: '🌤 Klart' },
-	{ value: 'RAIN', label: '🌧 Regn' },
-	{ value: 'WIND', label: '💨 Vind' },
-	{ value: 'SNOW', label: '❄️ Snø' },
-	{ value: 'FOG', label: '🌫 Tåke' },
-	{ value: 'THUNDER', label: '⛈ Torden' },
-	{ value: 'CHANGING_CONDITIONS', label: '🔄 Skiftende' },
-	{ value: 'OTHER', label: '🌡 Annet' },
+export const getStepLabels = (t: TranslationKeys): string[] => [
+	t['competitionStep.info'],
+	t['competitionStep.rounds'],
+	t['competitionStep.result'],
+	t['competitionStep.reflection'],
+];
+
+export const getWeatherOptions = (t: TranslationKeys): { value: WeatherCondition; label: string }[] => [
+	{ value: 'SUN', label: t['weather.sun'] },
+	{ value: 'CLOUDED', label: t['weather.clouded'] },
+	{ value: 'CLEAR', label: t['weather.clear'] },
+	{ value: 'RAIN', label: t['weather.rain'] },
+	{ value: 'WIND', label: t['weather.wind'] },
+	{ value: 'SNOW', label: t['weather.snow'] },
+	{ value: 'FOG', label: t['weather.fog'] },
+	{ value: 'THUNDER', label: t['weather.thunder'] },
+	{ value: 'CHANGING_CONDITIONS', label: t['weather.changing'] },
+	{ value: 'OTHER', label: t['weather.other'] },
 ];
 
 export interface CompetitionRoundInput {
@@ -56,7 +63,7 @@ export function emptyRound(cat: PracticeCategory): CompetitionRoundInput {
 		: { distanceMeters: undefined, targetType: '', numberArrows: undefined, arrowsWithoutScore: undefined, roundScore: 0 };
 }
 
-export function getRoundSummary(round: CompetitionRoundInput): string {
+export function getRoundSummary(round: CompetitionRoundInput, t: TranslationKeys): string {
 	const parts: string[] = [];
 	if (round.distanceMeters) parts.push(`${round.distanceMeters}m`);
 	if (round.distanceFrom || round.distanceTo) parts.push(`${round.distanceFrom ?? '?'}–${round.distanceTo ?? '?'}m`);
@@ -64,6 +71,6 @@ export function getRoundSummary(round: CompetitionRoundInput): string {
 		const opt = TARGET_TYPE_OPTIONS.find((o) => o.value === round.targetType);
 		parts.push(opt?.label ?? round.targetType);
 	}
-	return parts.length > 0 ? parts.join(' · ') : 'Ingen detaljer';
+	return parts.length > 0 ? parts.join(' · ') : t['round.noDetails'];
 }
 

--- a/components/Competitions/CompetitionFormModal.types.ts
+++ b/components/Competitions/CompetitionFormModal.types.ts
@@ -1,6 +1,6 @@
 import type { PracticeCategory, WeatherCondition } from '@/lib/prismaEnums';
 import { Environment } from '@/lib/prismaEnums';
-import { TARGET_TYPE_OPTIONS } from '@/lib/Contants';
+import { getTargetLabel } from '@/lib/Contants';
 import type { TranslationKeys } from '@/lib/i18n/types';
 
 export const TOTAL_STEPS = 4;
@@ -68,8 +68,7 @@ export function getRoundSummary(round: CompetitionRoundInput, t: TranslationKeys
 	if (round.distanceMeters) parts.push(`${round.distanceMeters}m`);
 	if (round.distanceFrom || round.distanceTo) parts.push(`${round.distanceFrom ?? '?'}–${round.distanceTo ?? '?'}m`);
 	if (round.targetType) {
-		const opt = TARGET_TYPE_OPTIONS.find((o) => o.value === round.targetType);
-		parts.push(opt?.label ?? round.targetType);
+		parts.push(getTargetLabel(round.targetType, t));
 	}
 	return parts.length > 0 ? parts.join(' · ') : t['round.noDetails'];
 }

--- a/components/Competitions/CompetitionFormNavFooter.tsx
+++ b/components/Competitions/CompetitionFormNavFooter.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import styles from './CompetitionFormModal.module.css';
 import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 import { Button } from '@/components';
-import { STEP_LABELS, TOTAL_STEPS } from './CompetitionFormModal.types';
+import { getStepLabels, TOTAL_STEPS } from './CompetitionFormModal.types';
 import { useTranslation } from '@/context/LanguageProvider';
 
 interface NavFooterProps {
@@ -20,6 +20,7 @@ interface NavFooterProps {
 
 export const CompetitionFormNavFooter: React.FC<NavFooterProps> = ({ step, onPrev, onNext, isEditMode, submitting, canSave, onSubmit }) => {
 	const { t } = useTranslation();
+	const stepLabels = getStepLabels(t);
 	const isFirstStep = step === 0;
 	const isLastStep = step === TOTAL_STEPS - 1;
 
@@ -36,7 +37,7 @@ export const CompetitionFormNavFooter: React.FC<NavFooterProps> = ({ step, onPre
 					<LuChevronLeft size={26} />
 				</button>
 
-				<span className={styles.navStepName}>{STEP_LABELS[step]}</span>
+				<span className={styles.navStepName}>{stepLabels[step]}</span>
 
 				<div className={styles.navRowRight}>
 					{isLastStep ? (

--- a/components/Competitions/CompetitionFormRoundsStep.tsx
+++ b/components/Competitions/CompetitionFormRoundsStep.tsx
@@ -5,7 +5,7 @@ import styles from './CompetitionFormModal.module.css';
 import { LuPlus, LuX } from 'react-icons/lu';
 import type { PracticeCategory } from '@/lib/prismaEnums';
 import { NumberInput, Select } from '@/components';
-import { TARGET_TYPE_OPTIONS } from '@/lib/Contants';
+import { getTargetTypeOptions } from '@/lib/Contants';
 import { type CompetitionRoundInput, isRangeCategory } from './CompetitionFormModal.types';
 import { useTranslation } from '@/context/LanguageProvider';
 
@@ -20,6 +20,7 @@ interface RoundsStepProps {
 export const CompetitionFormRoundsStep: React.FC<RoundsStepProps> = ({ rounds, practiceCategory, addRound, removeRound, updateRound }) => {
 	const { t } = useTranslation();
 	const rangeCategory = isRangeCategory(practiceCategory);
+	const targetTypeOptions = getTargetTypeOptions(t);
 
 	return (
 		<div className={styles.stepContent}>
@@ -77,7 +78,7 @@ export const CompetitionFormRoundsStep: React.FC<RoundsStepProps> = ({ rounds, p
 										onChange={(v) => updateRound(index, 'targetType', v as string)}
 										placeholderLabel={t['competition.rounds.select']}
 										searchable
-										options={TARGET_TYPE_OPTIONS}
+										options={targetTypeOptions}
 										containerClassName={styles.skiveField}
 									/>
 								</>

--- a/components/Competitions/CompetitionFormStepIndicator.tsx
+++ b/components/Competitions/CompetitionFormStepIndicator.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import styles from './CompetitionFormModal.module.css';
-import { STEP_LABELS, TOTAL_STEPS } from './CompetitionFormModal.types';
+import { getStepLabels, TOTAL_STEPS } from './CompetitionFormModal.types';
 import { useTranslation } from '@/context/LanguageProvider';
 
 interface StepIndicatorProps {
@@ -12,9 +12,10 @@ interface StepIndicatorProps {
 
 export const CompetitionFormStepIndicator: React.FC<StepIndicatorProps> = ({ step, onStepChange }) => {
 	const { t } = useTranslation();
+	const stepLabels = getStepLabels(t);
 	return (
 		<div className={styles.stepIndicator}>
-			{STEP_LABELS.map((label, i) => {
+			{stepLabels.map((label, i) => {
 				const isActive = i === step;
 				const isCompleted = i < step;
 				return (

--- a/components/Practices/PracticeFormInfoStep.tsx
+++ b/components/Practices/PracticeFormInfoStep.tsx
@@ -7,7 +7,7 @@ import type { PracticeCategory, WeatherCondition } from '@/lib/prismaEnums';
 import { Environment } from '@/lib/prismaEnums';
 import { DateInput, Input, Select } from '@/components';
 import { getArrowsOptions, getBowOptions, getEnvironmentOptions, getPracticeCategoryOptions } from '@/lib/formUtils';
-import { WEATHER_OPTIONS } from './PracticeFormModal.types';
+import { getWeatherOptions } from './PracticeFormModal.types';
 import { useTranslation } from '@/context/LanguageProvider';
 
 interface InfoStepProps {
@@ -52,10 +52,11 @@ export const PracticeFormInfoStep: React.FC<InfoStepProps> = ({
 	onDeleteRequest,
 }) => {
 	const { t } = useTranslation();
-	const environmentOptions = getEnvironmentOptions();
-	const practiceCategoryOptions = getPracticeCategoryOptions();
-	const bowOptions = getBowOptions(bows);
-	const arrowsOptions = getArrowsOptions(arrows);
+	const environmentOptions = getEnvironmentOptions(t);
+	const practiceCategoryOptions = getPracticeCategoryOptions(t);
+	const bowOptions = getBowOptions(bows, t);
+	const arrowsOptions = getArrowsOptions(arrows, t);
+	const weatherOptions = getWeatherOptions(t);
 
 	return (
 		<div className={styles.stepContent}>
@@ -92,7 +93,7 @@ export const PracticeFormInfoStep: React.FC<InfoStepProps> = ({
 				<div className={styles.weatherSection}>
 					<div className={styles.weatherLabel}>{t['form.weather']}</div>
 					<div className={styles.weatherChips}>
-						{WEATHER_OPTIONS.map((opt) => {
+						{weatherOptions.map((opt) => {
 							const active = weather.includes(opt.value);
 							return (
 								<button

--- a/components/Practices/PracticeFormModal.types.ts
+++ b/components/Practices/PracticeFormModal.types.ts
@@ -1,6 +1,6 @@
 import type { PracticeCategory, WeatherCondition } from '@/lib/prismaEnums';
 import { Environment } from '@/lib/prismaEnums';
-import { TARGET_TYPE_OPTIONS } from '@/lib/Contants';
+import { getTargetLabel } from '@/lib/Contants';
 import type { TranslationKeys } from '@/lib/i18n/types';
 
 // ─── Step definitions ─────────────────────────────────────────────────────────
@@ -93,8 +93,7 @@ export function getRoundSummary(round: RoundInput, t: TranslationKeys): string {
 	if (round.distanceMeters) parts.push(`${round.distanceMeters}m`);
 	if (round.distanceFrom || round.distanceTo) parts.push(`${round.distanceFrom ?? '?'}–${round.distanceTo ?? '?'}m`);
 	if (round.targetType) {
-		const opt = TARGET_TYPE_OPTIONS.find((o) => o.value === round.targetType);
-		parts.push(opt?.label ?? round.targetType);
+		parts.push(getTargetLabel(round.targetType, t));
 	}
 	return parts.length > 0 ? parts.join(' · ') : t['round.noDetails'];
 }

--- a/components/Practices/PracticeFormModal.types.ts
+++ b/components/Practices/PracticeFormModal.types.ts
@@ -1,23 +1,30 @@
 import type { PracticeCategory, WeatherCondition } from '@/lib/prismaEnums';
 import { Environment } from '@/lib/prismaEnums';
 import { TARGET_TYPE_OPTIONS } from '@/lib/Contants';
+import type { TranslationKeys } from '@/lib/i18n/types';
 
 // ─── Step definitions ─────────────────────────────────────────────────────────
 export const TOTAL_STEPS = 4;
-export const STEP_LABELS = ['Info', 'Runder', 'Poeng', 'Refleksjon'];
+
+export const getStepLabels = (t: TranslationKeys): string[] => [
+	t['practiceStep.info'],
+	t['practiceStep.rounds'],
+	t['practiceStep.scoring'],
+	t['practiceStep.reflection'],
+];
 
 // ─── Weather chip options ─────────────────────────────────────────────────────
-export const WEATHER_OPTIONS: { value: WeatherCondition; label: string }[] = [
-	{ value: 'SUN', label: '☀️ Sol' },
-	{ value: 'CLOUDED', label: '⛅ Skyet' },
-	{ value: 'CLEAR', label: '🌤 Klart' },
-	{ value: 'RAIN', label: '🌧 Regn' },
-	{ value: 'WIND', label: '💨 Vind' },
-	{ value: 'SNOW', label: '❄️ Snø' },
-	{ value: 'FOG', label: '🌫 Tåke' },
-	{ value: 'THUNDER', label: '⛈ Torden' },
-	{ value: 'CHANGING_CONDITIONS', label: '🔄 Skiftende' },
-	{ value: 'OTHER', label: '🌡 Annet' },
+export const getWeatherOptions = (t: TranslationKeys): { value: WeatherCondition; label: string }[] => [
+	{ value: 'SUN', label: t['weather.sun'] },
+	{ value: 'CLOUDED', label: t['weather.clouded'] },
+	{ value: 'CLEAR', label: t['weather.clear'] },
+	{ value: 'RAIN', label: t['weather.rain'] },
+	{ value: 'WIND', label: t['weather.wind'] },
+	{ value: 'SNOW', label: t['weather.snow'] },
+	{ value: 'FOG', label: t['weather.fog'] },
+	{ value: 'THUNDER', label: t['weather.thunder'] },
+	{ value: 'CHANGING_CONDITIONS', label: t['weather.changing'] },
+	{ value: 'OTHER', label: t['weather.other'] },
 ];
 
 // ─── Arrow score button options ───────────────────────────────────────────────
@@ -81,7 +88,7 @@ export function emptyRound(cat: PracticeCategory): RoundInput {
 		: { distanceMeters: undefined, targetType: '', numberArrows: undefined, arrowsWithoutScore: undefined, roundScore: 0, scores: [] };
 }
 
-export function getRoundSummary(round: RoundInput): string {
+export function getRoundSummary(round: RoundInput, t: TranslationKeys): string {
 	const parts: string[] = [];
 	if (round.distanceMeters) parts.push(`${round.distanceMeters}m`);
 	if (round.distanceFrom || round.distanceTo) parts.push(`${round.distanceFrom ?? '?'}–${round.distanceTo ?? '?'}m`);
@@ -89,5 +96,5 @@ export function getRoundSummary(round: RoundInput): string {
 		const opt = TARGET_TYPE_OPTIONS.find((o) => o.value === round.targetType);
 		parts.push(opt?.label ?? round.targetType);
 	}
-	return parts.length > 0 ? parts.join(' · ') : 'Ingen detaljer';
+	return parts.length > 0 ? parts.join(' · ') : t['round.noDetails'];
 }

--- a/components/Practices/PracticeFormNavFooter.tsx
+++ b/components/Practices/PracticeFormNavFooter.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import styles from './PracticeFormModal.module.css';
 import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 import { Button } from '@/components';
-import { STEP_LABELS, TOTAL_STEPS } from './PracticeFormModal.types';
+import { getStepLabels, TOTAL_STEPS } from './PracticeFormModal.types';
 import { useTranslation } from '@/context/LanguageProvider';
 
 interface NavFooterProps {
@@ -28,6 +28,7 @@ export const PracticeFormNavFooter: React.FC<NavFooterProps> = ({
 	onSubmit,
 }) => {
 	const { t } = useTranslation();
+	const stepLabels = getStepLabels(t);
 	const isFirstStep = step === 0;
 	const isLastStep = step === TOTAL_STEPS - 1;
 
@@ -44,7 +45,7 @@ export const PracticeFormNavFooter: React.FC<NavFooterProps> = ({
 					<LuChevronLeft size={26} />
 				</button>
 
-				<span className={styles.navStepName}>{STEP_LABELS[step]}</span>
+				<span className={styles.navStepName}>{stepLabels[step]}</span>
 
 				<div className={styles.navRowRight}>
 					{isLastStep ? (

--- a/components/Practices/PracticeFormRoundsStep.tsx
+++ b/components/Practices/PracticeFormRoundsStep.tsx
@@ -5,7 +5,7 @@ import styles from './PracticeFormModal.module.css';
 import { LuPlus, LuX } from 'react-icons/lu';
 import type { PracticeCategory } from '@/lib/prismaEnums';
 import { NumberInput, Select } from '@/components';
-import { TARGET_TYPE_OPTIONS } from '@/lib/Contants';
+import { getTargetTypeOptions } from '@/lib/Contants';
 import { type RoundInput, isRangeCategory } from './PracticeFormModal.types';
 import { useTranslation } from '@/context/LanguageProvider';
 
@@ -20,6 +20,7 @@ interface RoundsStepProps {
 export const PracticeFormRoundsStep: React.FC<RoundsStepProps> = ({ rounds, practiceCategory, addRound, removeRound, updateRound }) => {
 	const { t } = useTranslation();
 	const rangeCategory = isRangeCategory(practiceCategory);
+	const targetTypeOptions = getTargetTypeOptions(t);
 
 	return (
 		<div className={styles.stepContent}>
@@ -77,7 +78,7 @@ export const PracticeFormRoundsStep: React.FC<RoundsStepProps> = ({ rounds, prac
 										onChange={(v) => updateRound(index, 'targetType', v as string)}
 										placeholderLabel={t['form.choose']}
 										searchable
-										options={TARGET_TYPE_OPTIONS}
+										options={targetTypeOptions}
 										containerClassName={styles.skiveField}
 									/>
 								</>

--- a/components/Practices/PracticeFormScoringStep.tsx
+++ b/components/Practices/PracticeFormScoringStep.tsx
@@ -6,6 +6,7 @@ import { LuChevronLeft, LuChevronRight, LuInfo } from 'react-icons/lu';
 import { ARROW_SCORE_OPTIONS, type RoundInput, getRoundSummary } from './PracticeFormModal.types';
 import { Environment } from '@/lib/prismaEnums';
 import { Button } from '@/components';
+import { useTranslation } from '@/context/LanguageProvider';
 
 const DEFAULT_ARROWS_PER_END = 3;
 
@@ -52,6 +53,7 @@ interface ScoringStepProps {
 }
 
 export const PracticeFormScoringStep: React.FC<ScoringStepProps> = ({ rounds, environment, addArrowScore, updateArrowScore }) => {
+	const { t } = useTranslation();
 	const hasAnyActionable = rounds.some((r) => (r.numberArrows ?? 0) > 0 || r.roundScore > 0);
 
 	const scoreOptions = environment === Environment.OUTDOOR ? ARROW_SCORE_OPTIONS : ARROW_SCORE_OPTIONS.filter((opt) => opt.label !== 'X');
@@ -112,7 +114,7 @@ export const PracticeFormScoringStep: React.FC<ScoringStepProps> = ({ rounds, en
 						<div key={roundIndex} className={styles.scoringCard}>
 							<div className={styles.scoringCardHeader}>
 								<span className={styles.scoringRoundTitle}>Runde {roundIndex + 1}</span>
-								<span className={styles.scoringRoundMeta}>{getRoundSummary(round)}</span>
+								<span className={styles.scoringRoundMeta}>{getRoundSummary(round, t)}</span>
 							</div>
 							<div className={styles.manualScoreNotice}>
 								<LuInfo size={16} className={styles.manualScoreNoticeIcon} />
@@ -158,7 +160,7 @@ export const PracticeFormScoringStep: React.FC<ScoringStepProps> = ({ rounds, en
 					<div key={roundIndex} className={styles.scoringCard}>
 						<div className={styles.scoringCardHeader}>
 							<span className={styles.scoringRoundTitle}>Runde {roundIndex + 1}</span>
-							<span className={styles.scoringRoundMeta}>{getRoundSummary(round)}</span>
+							<span className={styles.scoringRoundMeta}>{getRoundSummary(round, t)}</span>
 						</div>
 
 						{totalEnds > 1 && (

--- a/components/Practices/PracticeFormStepIndicator.tsx
+++ b/components/Practices/PracticeFormStepIndicator.tsx
@@ -2,35 +2,40 @@
 
 import React from 'react';
 import styles from './PracticeFormModal.module.css';
-import { STEP_LABELS, TOTAL_STEPS } from './PracticeFormModal.types';
+import { getStepLabels, TOTAL_STEPS } from './PracticeFormModal.types';
+import { useTranslation } from '@/context/LanguageProvider';
 
 interface StepIndicatorProps {
 	step: number;
 	onStepChange: (index: number) => void;
 }
 
-export const PracticeFormStepIndicator: React.FC<StepIndicatorProps> = ({ step, onStepChange }) => (
-	<div className={styles.stepIndicator}>
-		{STEP_LABELS.map((label, i) => {
-			const isActive = i === step;
-			const isCompleted = i < step;
-			return (
-				<React.Fragment key={i}>
-					<button type="button" className={styles.stepItem} onClick={() => onStepChange(i)} aria-label={`Gå til ${label}`}>
-						<div
-							className={`${styles.stepDot}${isActive ? ` ${styles.stepDotActive}` : ''}${isCompleted ? ` ${styles.stepDotCompleted}` : ''}`}
-						>
-							<span className={`${styles.stepDotText}${isActive || isCompleted ? ` ${styles.stepDotTextActive}` : ''}`}>{i + 1}</span>
-						</div>
-						<span
-							className={`${styles.stepLabel}${isActive ? ` ${styles.stepLabelActive}` : ''}${isCompleted ? ` ${styles.stepLabelCompleted}` : ''}`}
-						>
-							{label}
-						</span>
-					</button>
-					{i < TOTAL_STEPS - 1 && <div className={`${styles.stepConnector}${isCompleted ? ` ${styles.stepConnectorCompleted}` : ''}`} />}
-				</React.Fragment>
-			);
-		})}
-	</div>
-);
+export const PracticeFormStepIndicator: React.FC<StepIndicatorProps> = ({ step, onStepChange }) => {
+	const { t } = useTranslation();
+	const stepLabels = getStepLabels(t);
+	return (
+		<div className={styles.stepIndicator}>
+			{stepLabels.map((label, i) => {
+				const isActive = i === step;
+				const isCompleted = i < step;
+				return (
+					<React.Fragment key={i}>
+						<button type="button" className={styles.stepItem} onClick={() => onStepChange(i)} aria-label={`${t['practice.stepGoTo']} ${label}`}>
+							<div
+								className={`${styles.stepDot}${isActive ? ` ${styles.stepDotActive}` : ''}${isCompleted ? ` ${styles.stepDotCompleted}` : ''}`}
+							>
+								<span className={`${styles.stepDotText}${isActive || isCompleted ? ` ${styles.stepDotTextActive}` : ''}`}>{i + 1}</span>
+							</div>
+							<span
+								className={`${styles.stepLabel}${isActive ? ` ${styles.stepLabelActive}` : ''}${isCompleted ? ` ${styles.stepLabelCompleted}` : ''}`}
+							>
+								{label}
+							</span>
+						</button>
+						{i < TOTAL_STEPS - 1 && <div className={`${styles.stepConnector}${isCompleted ? ` ${styles.stepConnectorCompleted}` : ''}`} />}
+					</React.Fragment>
+				);
+			})}
+		</div>
+	);
+};

--- a/components/ProfileEditModal/ProfileForm.tsx
+++ b/components/ProfileEditModal/ProfileForm.tsx
@@ -53,6 +53,7 @@ export function ProfileForm({ initialValues, loading, onSubmit, onCancel }: Prof
 				searchPlaceholder={t['profileEdit.clubSearchPlaceholder']}
 				createLabel={t['profileEdit.clubAddCustom']}
 				emptyText={t['common.noResults']}
+				searchMaxLength={100}
 			/>
 			<Input
 				label={t['profileEdit.archerNumberLabel']}

--- a/components/ProfileEditModal/ProfileForm.tsx
+++ b/components/ProfileEditModal/ProfileForm.tsx
@@ -44,11 +44,15 @@ export function ProfileForm({ initialValues, loading, onSubmit, onCancel }: Prof
 			<Input label={t['profileEdit.nameLabel']} value={name} onChange={(e) => setName(e.target.value)} helpText={t['profileEdit.nameHelp']} required />
 			<Select
 				searchable
+				creatable
 				label={t['profileEdit.clubLabel']}
 				value={club}
 				onChange={(val) => setClub(val as string)}
 				options={clubOptions}
 				helpText={t['profileEdit.clubHelp']}
+				searchPlaceholder={t['profileEdit.clubSearchPlaceholder']}
+				createLabel={t['profileEdit.clubAddCustom']}
+				emptyText={t['common.noResults']}
 			/>
 			<Input
 				label={t['profileEdit.archerNumberLabel']}

--- a/components/common/Select/Select.tsx
+++ b/components/common/Select/Select.tsx
@@ -46,6 +46,8 @@ export interface SelectProps {
 	creatable?: boolean;
 	/** Label prefix shown next to the typed query when offering to add it (e.g. "Add"). */
 	createLabel?: string;
+	/** Maximum number of characters allowed in the search input (also caps the value committed via `creatable`). */
+	searchMaxLength?: number;
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -70,6 +72,7 @@ export const Select: React.FC<SelectProps> = ({
 	searchPlaceholder = 'Søk...',
 	creatable = false,
 	createLabel = 'Legg til',
+	searchMaxLength,
 }) => {
 	const autoId = useId();
 	const selectId = id ?? `select-${autoId}`;
@@ -319,6 +322,7 @@ export const Select: React.FC<SelectProps> = ({
 											type="text"
 											className={styles.searchInput}
 											placeholder={searchPlaceholder}
+											maxLength={searchMaxLength}
 											value={searchQuery}
 											onChange={(e) => {
 												setSearchQuery(e.target.value);

--- a/components/common/Select/Select.tsx
+++ b/components/common/Select/Select.tsx
@@ -38,6 +38,14 @@ export interface SelectProps {
 	searchable?: boolean;
 	/** Placeholder text for the search input. */
 	searchPlaceholder?: string;
+	/**
+	 * When true, the search query (trimmed) can be committed as a custom value
+	 * if it doesn't exactly match any existing option label. Only meaningful
+	 * with `searchable`, and only for non-multiple selects.
+	 */
+	creatable?: boolean;
+	/** Label prefix shown next to the typed query when offering to add it (e.g. "Add"). */
+	createLabel?: string;
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -60,6 +68,8 @@ export const Select: React.FC<SelectProps> = ({
 	maxSelectedLabels = 2,
 	searchable = false,
 	searchPlaceholder = 'Søk...',
+	creatable = false,
+	createLabel = 'Legg til',
 }) => {
 	const autoId = useId();
 	const selectId = id ?? `select-${autoId}`;
@@ -103,6 +113,16 @@ export const Select: React.FC<SelectProps> = ({
 		if (multiple) return undefined;
 		return options.find((o) => o.value === value);
 	}, [multiple, options, value]);
+
+	// In creatable mode, a typed query that doesn't already match an option
+	// (by value or label, case-insensitive) is offered as a commit candidate.
+	const trimmedQuery = searchQuery.trim();
+	const showCreateOption = useMemo(() => {
+		if (!creatable || !searchable || multiple) return false;
+		if (!trimmedQuery) return false;
+		const q = trimmedQuery.toLowerCase();
+		return !options.some((o) => o.value.toLowerCase() === q || o.label.toLowerCase() === q);
+	}, [creatable, searchable, multiple, trimmedQuery, options]);
 
 	const selectedOptions = useMemo(() => {
 		if (!multiple) return [];
@@ -224,11 +244,23 @@ export const Select: React.FC<SelectProps> = ({
 	};
 
 	const buttonText = useMemo(() => {
-		if (!multiple) return selectedOption ? selectedOption.label : placeholderLabel || '';
+		if (!multiple) {
+			if (selectedOption) return selectedOption.label;
+			// Creatable: a value that isn't in `options` is a previously-typed custom entry
+			if (creatable && typeof value === 'string' && value) return value;
+			return placeholderLabel || '';
+		}
 		if (selectedOptions.length === 0) return placeholderLabel || '';
 		if (selectedOptions.length > maxSelectedLabels) return `${selectedOptions.length} valgt`;
 		return selectedOptions.map((o) => o.label).join(', ');
-	}, [maxSelectedLabels, multiple, placeholderLabel, selectedOption, selectedOptions]);
+	}, [creatable, maxSelectedLabels, multiple, placeholderLabel, selectedOption, selectedOptions, value]);
+
+	const commitCreated = () => {
+		if (!trimmedQuery) return;
+		onChange(trimmedQuery);
+		closeMenu();
+		buttonRef.current?.focus();
+	};
 
 	return (
 		<div className={`${styles.container} ${containerClassName || ''}`} ref={rootRef}>
@@ -297,9 +329,13 @@ export const Select: React.FC<SelectProps> = ({
 												if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
 													e.preventDefault();
 													moveActive(e.key === 'ArrowDown' ? 1 : -1);
-												} else if (e.key === 'Enter' && activeIndex >= 0) {
+												} else if (e.key === 'Enter') {
 													e.preventDefault();
-													commitIndex(activeIndex);
+													if (activeIndex >= 0 && hasEnabledOptions) {
+														commitIndex(activeIndex);
+													} else if (showCreateOption) {
+														commitCreated();
+													}
 												} else if (e.key === 'Escape') {
 													e.preventDefault();
 													closeMenu();
@@ -309,10 +345,25 @@ export const Select: React.FC<SelectProps> = ({
 										/>
 									</li>
 								) : null}
-								{filteredOptions.length === 0 || !hasEnabledOptions ? (
-									<li className={`${styles.option} ${styles.optionEmpty}`} role="option" aria-disabled="true">
-										<span className={styles.optionLabel}>{searchQuery ? 'Ingen treff' : emptyText}</span>
+								{showCreateOption ? (
+									<li
+										role="option"
+										aria-selected={false}
+										className={`${styles.option}`}
+										onMouseDown={(e) => e.preventDefault()}
+										onClick={commitCreated}
+									>
+										<span className={styles.optionText}>
+											<span className={styles.optionLabel}>{`${createLabel}: "${trimmedQuery}"`}</span>
+										</span>
 									</li>
+								) : null}
+								{filteredOptions.length === 0 || !hasEnabledOptions ? (
+									!showCreateOption ? (
+										<li className={`${styles.option} ${styles.optionEmpty}`} role="option" aria-disabled="true">
+											<span className={styles.optionLabel}>{searchQuery ? 'Ingen treff' : emptyText}</span>
+										</li>
+									) : null
 								) : (
 									filteredOptions.map((opt, idx) => {
 										const selected = multiple ? selectedSet.has(opt.value) : opt.value === value;

--- a/docs/API.md
+++ b/docs/API.md
@@ -185,6 +185,7 @@ Returns only the authenticated user. Prefer `GET /api/profile` for new code.
 
 - `image` accepts an external URL or a `data:image/...` base64 string up to 5 MB.
 - `locale` must be exactly `"no"`, `"en"`, or `null`. Any other value returns `400 Invalid locale. Must be "no" or "en".`.
+- `club` is free-text up to 100 characters after trimming. Empty strings are normalized to `null`. Non-string values return `400 Invalid club. Must be a string.`; over-length returns `400 Club name too long. Max 100 characters.`.
 
 **Response 200:**
 

--- a/lib/Contants.ts
+++ b/lib/Contants.ts
@@ -1,4 +1,5 @@
 import { AimDistanceMark } from '@/types/SightMarks';
+import type { TranslationKeys } from '@/lib/i18n/types';
 
 /**
  * Standard values for Ballistics calculations. These values are used to calculate the aim distance marks.
@@ -20,19 +21,35 @@ export const Ballistics: AimDistanceMark = {
 	feet_behind_or_center: 'behind',
 };
 
-export const TARGET_TYPE_OPTIONS = [
-	{ value: '40cm', label: '40 cm' },
-	{ value: '40cm-trippel-vegas', label: '40cm Trippel/Vegas' },
-	{ value: '60cm', label: '60 cm' },
-	{ value: '60cm-trippel', label: '60cm Trippel' },
-	{ value: '80cm', label: '80 cm' },
-	{ value: '80cm-centre-6', label: '80 cm Centre 6' },
-	{ value: '122cm', label: '122 cm' },
-	{ value: 'felt-20-trippel', label: 'Felt 20 cm Trippel' },
-	{ value: 'felt-40', label: 'Felt 40 cm' },
-	{ value: 'felt-60', label: 'Felt 60 cm' },
-	{ value: 'felt-80', label: 'Felt 80 cm' },
-	{ value: 'bar', label: 'Barmatte uten blink' },
-	{ value: 'historisk-nl-inne', label: 'Historisk NL Inne' },
-	{ value: 'other', label: 'Annet' },
+// Each target type has a stable `value` (used as the canonical identifier in
+// the DB and on the wire), a translation `key` for UI rendering, and a
+// Norwegian fallback `label` for server-side / locale-less consumers (stats
+// endpoint, validation). Validation and server-side aggregation read `value`
+// directly; UI consumers should call `getTargetTypeOptions(t)` for translated
+// labels.
+export const TARGET_TYPES: { value: string; key: keyof TranslationKeys; label: string }[] = [
+	{ value: '40cm', key: 'target.size40cm', label: '40 cm' },
+	{ value: '40cm-trippel-vegas', key: 'target.size40Triple', label: '40cm Trippel/Vegas' },
+	{ value: '60cm', key: 'target.size60cm', label: '60 cm' },
+	{ value: '60cm-trippel', key: 'target.size60Triple', label: '60cm Trippel' },
+	{ value: '80cm', key: 'target.size80cm', label: '80 cm' },
+	{ value: '80cm-centre-6', key: 'target.size80Centre6', label: '80 cm Centre 6' },
+	{ value: '122cm', key: 'target.size122cm', label: '122 cm' },
+	{ value: 'felt-20-trippel', key: 'target.field20Triple', label: 'Felt 20 cm Trippel' },
+	{ value: 'felt-40', key: 'target.field40', label: 'Felt 40 cm' },
+	{ value: 'felt-60', key: 'target.field60', label: 'Felt 60 cm' },
+	{ value: 'felt-80', key: 'target.field80', label: 'Felt 80 cm' },
+	{ value: 'bar', key: 'target.bareMat', label: 'Barmatte uten blink' },
+	{ value: 'historisk-nl-inne', key: 'target.historicNLIndoor', label: 'Historisk NL Inne' },
+	{ value: 'other', key: 'target.other', label: 'Annet' },
 ];
+
+export const TARGET_TYPE_OPTIONS = TARGET_TYPES.map(({ value, label }) => ({ value, label }));
+
+export const getTargetTypeOptions = (t: TranslationKeys) =>
+	TARGET_TYPES.map(({ value, key }) => ({ value, label: t[key] }));
+
+export const getTargetLabel = (value: string, t: TranslationKeys): string => {
+	const entry = TARGET_TYPES.find((o) => o.value === value);
+	return entry ? t[entry.key] : value;
+};

--- a/lib/formUtils.tsx
+++ b/lib/formUtils.tsx
@@ -1,30 +1,18 @@
-import { LuCloud, LuHouse, LuSparkles, LuSun, LuTarget, LuTrees, LuZap } from 'react-icons/lu';
-
-export const getWeatherSelectOptions = () => [
-	{ value: 'SUN', label: 'Sol', icon: <LuSun size={16} /> },
-	{ value: 'CLOUDED', label: 'Skyet', icon: <LuCloud size={16} /> },
-	{ value: 'CLEAR', label: 'Klarvær', icon: <LuSparkles size={16} /> },
-	{ value: 'RAIN', label: 'Regn', icon: <LuCloud size={16} /> },
-	{ value: 'WIND', label: 'Vind', icon: <LuCloud size={16} /> },
-	{ value: 'SNOW', label: 'Snø', icon: <LuCloud size={16} /> },
-	{ value: 'FOG', label: 'Tåke', icon: <LuCloud size={16} /> },
-	{ value: 'THUNDER', label: 'Torden', icon: <LuZap size={16} /> },
-	{ value: 'CHANGING_CONDITIONS', label: 'Skiftende forhold', icon: <LuCloud size={16} /> },
-	{ value: 'OTHER', label: 'Annet', icon: <LuCloud size={16} /> },
-];
+import { LuHouse, LuTarget, LuTrees } from 'react-icons/lu';
+import type { TranslationKeys } from '@/lib/i18n/types';
 
 // Shared environment options
-export const getEnvironmentOptions = () => [
-	{ value: 'INDOOR', label: 'Inne', icon: <LuHouse size={16} /> },
-	{ value: 'OUTDOOR', label: 'Ute', icon: <LuTrees size={16} /> },
+export const getEnvironmentOptions = (t: TranslationKeys) => [
+	{ value: 'INDOOR', label: t['environment.indoor'], icon: <LuHouse size={16} /> },
+	{ value: 'OUTDOOR', label: t['environment.outdoor'], icon: <LuTrees size={16} /> },
 ];
 
 // Shared practice category options
-export const getPracticeCategoryOptions = () => [
-	{ value: 'SKIVE_INDOOR', label: 'Skive innendørs', icon: <LuTarget size={16} /> },
-	{ value: 'SKIVE_OUTDOOR', label: 'Skive utendørs', icon: <LuTarget size={16} /> },
-	{ value: 'JAKT_3D', label: 'Jakt/3D', icon: <LuTrees size={16} /> },
-	{ value: 'FELT', label: 'Felt', icon: <LuTrees size={16} /> },
+export const getPracticeCategoryOptions = (t: TranslationKeys) => [
+	{ value: 'SKIVE_INDOOR', label: t['practiceCategory.skiveIndoor'], icon: <LuTarget size={16} /> },
+	{ value: 'SKIVE_OUTDOOR', label: t['practiceCategory.skiveOutdoor'], icon: <LuTarget size={16} /> },
+	{ value: 'JAKT_3D', label: t['practiceCategory.jakt3D'], icon: <LuTrees size={16} /> },
+	{ value: 'FELT', label: t['practiceCategory.felt'], icon: <LuTrees size={16} /> },
 ];
 
 // Shared types
@@ -43,12 +31,12 @@ export interface ArrowsOption {
 }
 
 // Helper to get equipment select options
-export const getBowOptions = (bows: EquipmentOption[]) => [
-	{ value: '', label: 'Ingen valgt' },
+export const getBowOptions = (bows: EquipmentOption[], t: TranslationKeys) => [
+	{ value: '', label: t['form.noneSelected'] },
 	...bows.map((b) => ({ value: b.id, label: `${b.name} (${b.type})` })),
 ];
 
-export const getArrowsOptions = (arrows: ArrowsOption[]) => [
-	{ value: '', label: 'Ingen valgt' },
+export const getArrowsOptions = (arrows: ArrowsOption[], t: TranslationKeys) => [
+	{ value: '', label: t['form.noneSelected'] },
 	...arrows.map((a) => ({ value: a.id, label: `${a.name} (${a.material})` })),
 ];

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -78,6 +78,44 @@ export const en: TranslationKeys = {
   'label.envOutdoor': 'Outdoor',
   'label.anonymousArcher': 'Anonymous archer',
 
+  // Practice category options
+  'practiceCategory.skiveIndoor': 'Target indoor',
+  'practiceCategory.skiveOutdoor': 'Target outdoor',
+  'practiceCategory.jakt3D': 'Hunting/3D',
+  'practiceCategory.felt': 'Field',
+
+  // Environment options
+  'environment.indoor': 'Indoor',
+  'environment.outdoor': 'Outdoor',
+
+  // Weather
+  'weather.sun': '☀️ Sun',
+  'weather.clouded': '⛅ Cloudy',
+  'weather.clear': '🌤 Clear',
+  'weather.rain': '🌧 Rain',
+  'weather.wind': '💨 Wind',
+  'weather.snow': '❄️ Snow',
+  'weather.fog': '🌫 Fog',
+  'weather.thunder': '⛈ Thunder',
+  'weather.changing': '🔄 Changing',
+  'weather.other': '🌡 Other',
+
+  // Practice form steps
+  'practiceStep.info': 'Info',
+  'practiceStep.rounds': 'Rounds',
+  'practiceStep.scoring': 'Scoring',
+  'practiceStep.reflection': 'Reflection',
+  'practice.stepGoTo': 'Go to',
+
+  // Competition form steps
+  'competitionStep.info': 'Info',
+  'competitionStep.rounds': 'Rounds',
+  'competitionStep.result': 'Result',
+  'competitionStep.reflection': 'Reflection',
+
+  // Round summary fallback
+  'round.noDetails': 'No details',
+
   // Dashboard
   'dashboard.errorLoading': 'Could not load user data',
   'dashboard.loginRequired': 'You must be logged in to view this page',
@@ -210,6 +248,7 @@ export const en: TranslationKeys = {
   'form.arrowsWithoutScore': 'Arrows w/o score',
   'form.from': 'From',
   'form.to': 'To',
+  'form.noneSelected': 'None selected',
 
   // Confirm modal defaults
   'confirm.defaultConfirm': 'Confirm',

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -116,6 +116,22 @@ export const en: TranslationKeys = {
   // Round summary fallback
   'round.noDetails': 'No details',
 
+  // Target types
+  'target.size40cm': '40 cm',
+  'target.size40Triple': '40 cm Triple/Vegas',
+  'target.size60cm': '60 cm',
+  'target.size60Triple': '60 cm Triple',
+  'target.size80cm': '80 cm',
+  'target.size80Centre6': '80 cm Centre 6',
+  'target.size122cm': '122 cm',
+  'target.field20Triple': 'Field 20 cm Triple',
+  'target.field40': 'Field 40 cm',
+  'target.field60': 'Field 60 cm',
+  'target.field80': 'Field 80 cm',
+  'target.bareMat': 'Bare mat (no face)',
+  'target.historicNLIndoor': 'Historic NL Indoor',
+  'target.other': 'Other',
+
   // Dashboard
   'dashboard.errorLoading': 'Could not load user data',
   'dashboard.loginRequired': 'You must be logged in to view this page',

--- a/lib/i18n/translations/en.ts
+++ b/lib/i18n/translations/en.ts
@@ -611,6 +611,8 @@ export const en: TranslationKeys = {
   'profileEdit.nameHelp': 'Your full name',
   'profileEdit.clubLabel': 'Club',
   'profileEdit.clubHelp': 'Your club',
+  'profileEdit.clubSearchPlaceholder': 'Search or type your club name…',
+  'profileEdit.clubAddCustom': 'Add',
   'profileEdit.archerNumberLabel': 'Archer number',
   'profileEdit.archerNumberHelp': 'Your archer number',
 

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -78,6 +78,44 @@ export const no: TranslationKeys = {
   'label.envOutdoor': 'Utendørs',
   'label.anonymousArcher': 'Anonym skytte',
 
+  // Practice category options
+  'practiceCategory.skiveIndoor': 'Skive innendørs',
+  'practiceCategory.skiveOutdoor': 'Skive utendørs',
+  'practiceCategory.jakt3D': 'Jakt/3D',
+  'practiceCategory.felt': 'Felt',
+
+  // Environment options
+  'environment.indoor': 'Inne',
+  'environment.outdoor': 'Ute',
+
+  // Weather
+  'weather.sun': '☀️ Sol',
+  'weather.clouded': '⛅ Skyet',
+  'weather.clear': '🌤 Klart',
+  'weather.rain': '🌧 Regn',
+  'weather.wind': '💨 Vind',
+  'weather.snow': '❄️ Snø',
+  'weather.fog': '🌫 Tåke',
+  'weather.thunder': '⛈ Torden',
+  'weather.changing': '🔄 Skiftende',
+  'weather.other': '🌡 Annet',
+
+  // Practice form steps
+  'practiceStep.info': 'Info',
+  'practiceStep.rounds': 'Runder',
+  'practiceStep.scoring': 'Poeng',
+  'practiceStep.reflection': 'Refleksjon',
+  'practice.stepGoTo': 'Gå til',
+
+  // Competition form steps
+  'competitionStep.info': 'Info',
+  'competitionStep.rounds': 'Runder',
+  'competitionStep.result': 'Resultat',
+  'competitionStep.reflection': 'Refleksjon',
+
+  // Round summary fallback
+  'round.noDetails': 'Ingen detaljer',
+
   // Dashboard
   'dashboard.errorLoading': 'Kunne ikke hente brukerdata',
   'dashboard.loginRequired': 'Du må logge inn for å se denne siden',
@@ -210,6 +248,7 @@ export const no: TranslationKeys = {
   'form.arrowsWithoutScore': 'Piler u/score',
   'form.from': 'Fra',
   'form.to': 'Til',
+  'form.noneSelected': 'Ingen valgt',
 
   // Confirm modal defaults
   'confirm.defaultConfirm': 'Bekreft',

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -611,6 +611,8 @@ export const no: TranslationKeys = {
   'profileEdit.nameHelp': 'Ditt fulle navn',
   'profileEdit.clubLabel': 'Klubb',
   'profileEdit.clubHelp': 'Klubben din',
+  'profileEdit.clubSearchPlaceholder': 'Søk eller skriv klubbnavn…',
+  'profileEdit.clubAddCustom': 'Legg til',
   'profileEdit.archerNumberLabel': 'Skytternr',
   'profileEdit.archerNumberHelp': 'Ditt skytternummer',
 

--- a/lib/i18n/translations/no.ts
+++ b/lib/i18n/translations/no.ts
@@ -116,6 +116,22 @@ export const no: TranslationKeys = {
   // Round summary fallback
   'round.noDetails': 'Ingen detaljer',
 
+  // Target types
+  'target.size40cm': '40 cm',
+  'target.size40Triple': '40cm Trippel/Vegas',
+  'target.size60cm': '60 cm',
+  'target.size60Triple': '60cm Trippel',
+  'target.size80cm': '80 cm',
+  'target.size80Centre6': '80 cm Centre 6',
+  'target.size122cm': '122 cm',
+  'target.field20Triple': 'Felt 20 cm Trippel',
+  'target.field40': 'Felt 40 cm',
+  'target.field60': 'Felt 60 cm',
+  'target.field80': 'Felt 80 cm',
+  'target.bareMat': 'Barmatte uten blink',
+  'target.historicNLIndoor': 'Historisk NL Inne',
+  'target.other': 'Annet',
+
   // Dashboard
   'dashboard.errorLoading': 'Kunne ikke hente brukerdata',
   'dashboard.loginRequired': 'Du må logge inn for å se denne siden',

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -116,6 +116,22 @@ export interface TranslationKeys {
   // Round summary fallback (when no distance/target chosen yet)
   'round.noDetails': string;
 
+  // Target type labels (used in the rounds step Target select and round summary)
+  'target.size40cm': string;
+  'target.size40Triple': string;
+  'target.size60cm': string;
+  'target.size60Triple': string;
+  'target.size80cm': string;
+  'target.size80Centre6': string;
+  'target.size122cm': string;
+  'target.field20Triple': string;
+  'target.field40': string;
+  'target.field60': string;
+  'target.field80': string;
+  'target.bareMat': string;
+  'target.historicNLIndoor': string;
+  'target.other': string;
+
   // Dashboard
   'dashboard.errorLoading': string;
   'dashboard.loginRequired': string;

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -78,6 +78,44 @@ export interface TranslationKeys {
   'label.envOutdoor': string;
   'label.anonymousArcher': string;
 
+  // Practice category options (used in the practice/competition form Category select)
+  'practiceCategory.skiveIndoor': string;
+  'practiceCategory.skiveOutdoor': string;
+  'practiceCategory.jakt3D': string;
+  'practiceCategory.felt': string;
+
+  // Environment options (used in the practice/competition form Environment select)
+  'environment.indoor': string;
+  'environment.outdoor': string;
+
+  // Weather chip / select labels
+  'weather.sun': string;
+  'weather.clouded': string;
+  'weather.clear': string;
+  'weather.rain': string;
+  'weather.wind': string;
+  'weather.snow': string;
+  'weather.fog': string;
+  'weather.thunder': string;
+  'weather.changing': string;
+  'weather.other': string;
+
+  // Practice form step indicator + navigation
+  'practiceStep.info': string;
+  'practiceStep.rounds': string;
+  'practiceStep.scoring': string;
+  'practiceStep.reflection': string;
+  'practice.stepGoTo': string;
+
+  // Competition form step indicator
+  'competitionStep.info': string;
+  'competitionStep.rounds': string;
+  'competitionStep.result': string;
+  'competitionStep.reflection': string;
+
+  // Round summary fallback (when no distance/target chosen yet)
+  'round.noDetails': string;
+
   // Dashboard
   'dashboard.errorLoading': string;
   'dashboard.loginRequired': string;
@@ -210,6 +248,7 @@ export interface TranslationKeys {
   'form.arrowsWithoutScore': string;
   'form.from': string;
   'form.to': string;
+  'form.noneSelected': string;
 
   // Confirm modal defaults
   'confirm.defaultConfirm': string;

--- a/lib/i18n/types.ts
+++ b/lib/i18n/types.ts
@@ -575,6 +575,8 @@ export interface TranslationKeys {
   'profileEdit.nameHelp': string;
   'profileEdit.clubLabel': string;
   'profileEdit.clubHelp': string;
+  'profileEdit.clubSearchPlaceholder': string;
+  'profileEdit.clubAddCustom': string;
   'profileEdit.archerNumberLabel': string;
   'profileEdit.archerNumberHelp': string;
 


### PR DESCRIPTION
## Summary
- Translate the remaining hardcoded Norwegian strings in the practice and competition form wizards — step indicator labels, environment / category / weather options, target type labels in the rounds step, equipment placeholders, and the round summary fallback.
- Replace the closed Norwegian-only club picker on the profile form with a creatable variant of the shared `Select`, so users outside Norway can enter their own club. Off-list values round-trip correctly through the form.
- Validate `club` on `PATCH /api/users`: must be a string, trimmed, ≤ 100 characters. Empty strings normalize to `null`. The Select search input is capped client-side to match.
- Update `docs/API.md` to document the new `club` validation rules.

## Why
- A previous round of i18n missed several form internals (option arrays, step labels, target labels) because they lived in helpers rather than directly in TSX. English users still saw Norwegian text in the practice/competition wizards.
- We launched the English locale to users outside Norway, but the profile club field was a closed list of Norwegian-federation clubs, so non-Norwegian users had no way to identify their club.

## Test plan
- [x] \`npm test\` — 322 tests, all green
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [ ] Open the practice form in \`no\` and \`en\` locales, confirm step labels, Category, Environment, weather chips, and Target options all switch language
- [ ] Same for the competition form
- [ ] In the profile edit modal, type a non-Norwegian club name, confirm the \"Add: <name>\" row appears, click it, save, and reopen — the custom value should still display
- [ ] \`PATCH /api/users\` with a 101-character \`club\` returns 400; with a short string round-trips correctly

## Notes for reviewer
- \`lib/Contants.ts\` now exports both \`TARGET_TYPE_OPTIONS\` (Norwegian labels, used by \`/api/stats/detailed\` and validation which only care about values) and \`getTargetTypeOptions(t)\` / \`getTargetLabel(value, t)\` (translated, used by UI). Worth a quick read.
- The stats endpoint still returns Norwegian series names regardless of UI locale — flagged in the earlier session as a follow-up; not addressed here.
- No data normalization on the new free-text club entries (just trim). Public-profile search may fragment if many users type variations of the same club name. Acceptable for v1; revisit if it becomes a real problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)