### PR TITLE
fix: resolve image 404s on Netlify

### DIFF
--- a/app/sponsing/page.tsx
+++ b/app/sponsing/page.tsx
@@ -18,7 +18,7 @@ export default function SponsingPage() {
 		},
 		{
 			name: 'Norges Bueskytterforbund',
-			logo: '/assets/norgesBueskytterforbund.png',
+			logo: '/assets/norgesbueskytterforbund.png',
 			website: 'https://www.bueskyting.no',
 			description: 'Norges Bueskytterforbund',
 		},

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,10 +15,9 @@ const nextConfig = {
 		},
 	}),
 
-	// Optimize images
+	// Bypass Next.js image optimization — Netlify's /_next/image endpoint returns 404
 	images: {
-		formats: ['image/avif', 'image/webp'],
-		minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
+		unoptimized: true,
 		remotePatterns: [
 			{
 				protocol: 'https',


### PR DESCRIPTION
## Summary
- Fix case mismatch in sponsor logo filename (`norgesBueskytterforbund.png` → `norgesbueskytterforbund.png`) that caused a 404 on Netlify's case-sensitive Linux filesystem
- Disable Next.js image optimization (`images.unoptimized: true`) because Netlify's `/_next/image` endpoint returns 404 for all sizes — images are now served directly from `/public`, which works correctly

## Context
The raw images at `/assets/*` load fine, but every request through `/_next/image?url=...` returns 404 on Netlify. This broke all `next/image` components site-wide. Setting `unoptimized: true` bypasses the broken endpoint. Netlify's CDN still provides caching and compression.

## Test plan
- [ ] Verify sponsor page loads the Norges Bueskytterforbund logo
- [ ] Verify images load on all pages (header logo, hero, footer, contributors, etc.)
- [ ] Check browser dev tools for 404s on image requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)