### PR TITLE
fix(api): prevent stats data leaking between users via CDN cache

### DIFF
--- a/app/api/sight-marks/[id]/results/route.ts
+++ b/app/api/sight-marks/[id]/results/route.ts
@@ -17,7 +17,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 		if (!sightMark) return NextResponse.json({ error: 'Sight mark not found' }, { status: 404 });
 
 		const results = await prisma.sightMarkResult.findMany({
-			where: { sightMarkId },
+			where: { sightMarkId, userId: user.id },
 			orderBy: { createdAt: 'desc' },
 		});
 

--- a/app/api/stats/detailed/route.ts
+++ b/app/api/stats/detailed/route.ts
@@ -37,7 +37,8 @@ export async function GET(request: Request) {
 		if (cached) {
 			return NextResponse.json(cached, {
 				headers: {
-					'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+					'Cache-Control': 'private, max-age=10, must-revalidate',
+					Vary: 'Cookie',
 				},
 			});
 		}
@@ -216,7 +217,8 @@ export async function GET(request: Request) {
 
 		return NextResponse.json(result, {
 			headers: {
-				'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+				'Cache-Control': 'private, max-age=10, must-revalidate',
+				Vary: 'Cookie',
 			},
 		});
 	} catch (error) {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -20,7 +20,8 @@ export async function GET(request: Request) {
 		if (cached) {
 			return NextResponse.json(cached, {
 				headers: {
-					'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+					'Cache-Control': 'private, max-age=10, must-revalidate',
+					Vary: 'Cookie',
 				},
 			});
 		}
@@ -133,7 +134,8 @@ export async function GET(request: Request) {
 
 		return NextResponse.json(result, {
 			headers: {
-				'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+				'Cache-Control': 'private, max-age=10, must-revalidate',
+				Vary: 'Cookie',
 			},
 		});
 	} catch (error) {}


### PR DESCRIPTION
## Summary
- **Stats endpoints used `Cache-Control: public, s-maxage=180`**, which told Vercel's edge to cache and serve one user's stats response to all users for 3 minutes. Changed to `private, max-age=10, must-revalidate` with `Vary: Cookie` — matching the pattern already used by `/api/practices/cards`.
- **Sight mark results query** was missing a `userId` filter on the `findMany` call, relying only on parent ownership check. Added `userId` to the where clause for defense in depth.

## Affected endpoints
- `app/api/stats/route.ts` — summary stats (cache-control fix)
- `app/api/stats/detailed/route.ts` — detailed stats (cache-control fix)
- `app/api/sight-marks/[id]/results/route.ts` — sight mark results (userId filter)

## Test plan
- [x] All 224 existing tests pass
- [ ] Verify stats summary cards show correct per-user data after deploy
- [ ] Verify detailed statistics screen shows correct per-user data
- [ ] Verify response headers include `Cache-Control: private` and `Vary: Cookie`

🤖 Generated with [Claude Code](https://claude.com/claude-code)