### PR TITLE
Release: fix stats data leak between users

### DIFF
--- a/app/api/sight-marks/[id]/results/route.ts
+++ b/app/api/sight-marks/[id]/results/route.ts
@@ -17,7 +17,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 		if (!sightMark) return NextResponse.json({ error: 'Sight mark not found' }, { status: 404 });
 
 		const results = await prisma.sightMarkResult.findMany({
-			where: { sightMarkId },
+			where: { sightMarkId, userId: user.id },
 			orderBy: { createdAt: 'desc' },
 		});
 

--- a/app/api/stats/detailed/route.ts
+++ b/app/api/stats/detailed/route.ts
@@ -37,7 +37,8 @@ export async function GET(request: Request) {
 		if (cached) {
 			return NextResponse.json(cached, {
 				headers: {
-					'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+					'Cache-Control': 'private, max-age=10, must-revalidate',
+					Vary: 'Cookie',
 				},
 			});
 		}
@@ -216,7 +217,8 @@ export async function GET(request: Request) {
 
 		return NextResponse.json(result, {
 			headers: {
-				'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+				'Cache-Control': 'private, max-age=10, must-revalidate',
+				Vary: 'Cookie',
 			},
 		});
 	} catch (error) {

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -20,7 +20,8 @@ export async function GET(request: Request) {
 		if (cached) {
 			return NextResponse.json(cached, {
 				headers: {
-					'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+					'Cache-Control': 'private, max-age=10, must-revalidate',
+					Vary: 'Cookie',
 				},
 			});
 		}
@@ -133,7 +134,8 @@ export async function GET(request: Request) {
 
 		return NextResponse.json(result, {
 			headers: {
-				'Cache-Control': 'public, s-maxage=180, stale-while-revalidate=300',
+				'Cache-Control': 'private, max-age=10, must-revalidate',
+				Vary: 'Cookie',
 			},
 		});
 	} catch (error) {}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,14 +7,6 @@ const nextConfig = {
 	// Enable source maps for production (improves debugging and Lighthouse Best Practices score)
 	productionBrowserSourceMaps: true,
 
-	// Development optimizations
-	...(process.env.NODE_ENV === 'development' && {
-		experimental: {
-			// Disable caching in development for fast refresh
-			isrMemoryCacheSize: 0,
-		},
-	}),
-
 	// Bypass Next.js image optimization — Netlify's /_next/image endpoint returns 404
 	images: {
 		unoptimized: true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"scripts": {
 		"prepare": "husky",
-		"dev": "next dev",
+		"dev": "NODE_OPTIONS='--max-old-space-size=4096' next dev",
 		"build": "next build",
 		"start": "next start",
 		"lint": "eslint .",


### PR DESCRIPTION
## Summary
- **Fix critical data leak**: stats API endpoints used `Cache-Control: public`, causing Vercel's edge to serve one user's cached stats to all users. Changed to `private` with `Vary: Cookie`.
- **Fix sight mark results query**: added missing `userId` filter for defense in depth.
- **Chore**: remove deprecated `isrMemoryCacheSize` config, increase Node dev server memory.

## Commits included
- `fix(api): change stats summary cache-control from public to private`
- `fix(api): change detailed stats cache-control from public to private`
- `fix(api): add userId filter to sight mark results query`
- `chore(config): remove deprecated isrMemoryCacheSize experimental option`
- `chore: increase Node memory limit for dev server`

## Test plan
- [x] All 224 tests pass
- [ ] Verify stats are user-scoped after production deploy
- [ ] Verify response headers show `Cache-Control: private`

🤖 Generated with [Claude Code](https://claude.com/claude-code)