### PR TITLE
fix(api): prevent browser from caching stale stats

### DIFF
--- a/app/api/stats/detailed/route.ts
+++ b/app/api/stats/detailed/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: Request) {
 		if (cached) {
 			return NextResponse.json(cached, {
 				headers: {
-					'Cache-Control': 'private, max-age=10, must-revalidate',
+					'Cache-Control': 'no-store',
 					Vary: 'Cookie',
 				},
 			});
@@ -217,7 +217,7 @@ export async function GET(request: Request) {
 
 		return NextResponse.json(result, {
 			headers: {
-				'Cache-Control': 'private, max-age=10, must-revalidate',
+				'Cache-Control': 'no-store',
 				Vary: 'Cookie',
 			},
 		});

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: Request) {
 		if (cached) {
 			return NextResponse.json(cached, {
 				headers: {
-					'Cache-Control': 'private, max-age=10, must-revalidate',
+					'Cache-Control': 'no-store',
 					Vary: 'Cookie',
 				},
 			});
@@ -134,7 +134,7 @@ export async function GET(request: Request) {
 
 		return NextResponse.json(result, {
 			headers: {
-				'Cache-Control': 'private, max-age=10, must-revalidate',
+				'Cache-Control': 'no-store',
 				Vary: 'Cookie',
 			},
 		});


### PR DESCRIPTION
## Summary
- Changed `Cache-Control` on both stats endpoints from `private, max-age=10, must-revalidate` to `no-store`
- The `max-age=10` allowed the browser to serve stale stats when `fetchStats()` was called immediately after creating/editing/deleting a practice or competition
- The server-side `MemoryCache` (3-min TTL, properly invalidated on mutations) is the actual caching layer — the browser HTTP cache was redundant and caused staleness

## Context
The `min-side` page already calls `fetchStats()` after every mutation (create, edit, delete for both practices and competitions). The issue was that the browser served its cached response instead of hitting the server, so the user saw stale numbers in the summary cards.

## Test plan
- [x] All 224 tests pass
- [ ] Create a practice on min-side → verify StatsSummary arrow count updates immediately
- [ ] Edit a practice → verify stats update
- [ ] Delete a practice → verify stats update
- [ ] Same for competitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)