### PR TITLE
fix(api): include unscored arrows in achievement counting

### DIFF
--- a/app/api/achievements/check/route.ts
+++ b/app/api/achievements/check/route.ts
@@ -23,6 +23,7 @@ export async function POST(request: Request) {
 					ends: {
 						select: {
 							arrows: true,
+							arrowsWithoutScore: true,
 							scores: true,
 							roundScore: true,
 						},
@@ -41,6 +42,7 @@ export async function POST(request: Request) {
 					rounds: {
 						select: {
 							arrows: true,
+							arrowsWithoutScore: true,
 							scores: true,
 							roundScore: true,
 						},
@@ -61,6 +63,7 @@ export async function POST(request: Request) {
 			practiceType: 'TRENING',
 			ends: practice.ends.map((end) => ({
 				arrows: end.arrows || 0,
+				arrowsWithoutScore: end.arrowsWithoutScore || 0,
 				scores: end.scores,
 				roundScore: end.roundScore,
 			})),
@@ -73,6 +76,7 @@ export async function POST(request: Request) {
 			practiceCategory: comp.practiceCategory,
 			ends: comp.rounds.map((round) => ({
 				arrows: round.arrows || 0,
+				arrowsWithoutScore: round.arrowsWithoutScore || 0,
 				scores: round.scores,
 				roundScore: round.roundScore,
 			})),

--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -22,6 +22,7 @@ export async function GET(request: Request) {
 					ends: {
 						select: {
 							arrows: true,
+							arrowsWithoutScore: true,
 							scores: true,
 							roundScore: true,
 						},
@@ -40,6 +41,7 @@ export async function GET(request: Request) {
 					rounds: {
 						select: {
 							arrows: true,
+							arrowsWithoutScore: true,
 							scores: true,
 							roundScore: true,
 						},
@@ -60,6 +62,7 @@ export async function GET(request: Request) {
 			practiceType: 'TRENING',
 			ends: practice.ends.map((end) => ({
 				arrows: end.arrows || 0,
+				arrowsWithoutScore: end.arrowsWithoutScore || 0,
 				scores: end.scores,
 				roundScore: end.roundScore,
 			})),
@@ -72,6 +75,7 @@ export async function GET(request: Request) {
 			practiceCategory: comp.practiceCategory,
 			ends: comp.rounds.map((round) => ({
 				arrows: round.arrows || 0,
+				arrowsWithoutScore: round.arrowsWithoutScore || 0,
 				scores: round.scores,
 				roundScore: round.roundScore,
 			})),

--- a/lib/achievements/checker.ts
+++ b/lib/achievements/checker.ts
@@ -19,6 +19,7 @@ interface PracticeData {
 	} | null;
 	ends?: Array<{
 		arrows: number;
+		arrowsWithoutScore?: number;
 		scores?: number[];
 		roundScore?: number | null;
 	}>;
@@ -61,7 +62,10 @@ export function calculateUserStats(practices: PracticeData[]): UserStats {
 		let practiceArrows = 0;
 
 		if (practice.ends && Array.isArray(practice.ends)) {
-			practiceArrows = practice.ends.reduce((sum: number, end: any) => sum + (end.arrows || 0), 0);
+			practiceArrows = practice.ends.reduce(
+				(sum: number, end: any) => sum + (end.arrows || 0) + (end.arrowsWithoutScore || 0),
+				0
+			);
 			stats.totalArrows += practiceArrows;
 		}
 
@@ -196,7 +200,9 @@ export function checkRequirement(
 		case 'ARROWS_IN_SESSION':
 			// Check if any single practice has >= value arrows
 			const maxArrowsInSession = Math.max(
-				...practices.map((p) => p.ends?.reduce((sum: number, end: any) => sum + (end.arrows || 0), 0) || 0),
+				...practices.map(
+					(p) => p.ends?.reduce((sum: number, end: any) => sum + (end.arrows || 0) + (end.arrowsWithoutScore || 0), 0) || 0
+				),
 				0
 			);
 			current = maxArrowsInSession;


### PR DESCRIPTION
## Summary
- Achievement endpoints (`GET /achievements`, `POST /achievements/check`) only counted scored arrows (`arrows` field), ignoring `arrowsWithoutScore` from ends and competition rounds
- This caused `ARROW_COUNT`, `ARROWS_IN_SESSION`, and `BOW_TYPE_ARROWS` achievement progress to undercount
- `SCORE_AVERAGE` intentionally still uses scored arrows only to avoid diluting the average

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 224 tests pass
- [x] ESLint passes (0 errors)
- [ ] Verify achievement progress numbers increase for users with unscored arrows
- [ ] Confirm `SCORE_AVERAGE` achievements are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)