### PR TITLE
fix(api): correct arrow counting for achievements

### DIFF
--- a/app/api/achievements/check/route.ts
+++ b/app/api/achievements/check/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: Request) {
 			...practice,
 			practiceType: 'TRENING',
 			ends: practice.ends.map((end) => ({
-				arrows: end.arrows ?? end.scores.length ?? 0,
+				arrows: end.arrows || end.scores?.length || 0,
 				arrowsWithoutScore: end.arrowsWithoutScore || 0,
 				scores: end.scores,
 				roundScore: end.roundScore,
@@ -75,7 +75,7 @@ export async function POST(request: Request) {
 			practiceType: 'KONKURRANSE',
 			practiceCategory: comp.practiceCategory,
 			ends: comp.rounds.map((round) => ({
-				arrows: round.arrows ?? round.scores.length ?? 0,
+				arrows: round.arrows || round.scores?.length || 0,
 				arrowsWithoutScore: round.arrowsWithoutScore || 0,
 				scores: round.scores,
 				roundScore: round.roundScore,

--- a/app/api/achievements/route.ts
+++ b/app/api/achievements/route.ts
@@ -61,7 +61,7 @@ export async function GET(request: Request) {
 			...practice,
 			practiceType: 'TRENING',
 			ends: practice.ends.map((end) => ({
-				arrows: end.arrows ?? end.scores.length ?? 0,
+				arrows: end.arrows || end.scores?.length || 0,
 				arrowsWithoutScore: end.arrowsWithoutScore || 0,
 				scores: end.scores,
 				roundScore: end.roundScore,
@@ -74,7 +74,7 @@ export async function GET(request: Request) {
 			practiceType: 'KONKURRANSE',
 			practiceCategory: comp.practiceCategory,
 			ends: comp.rounds.map((round) => ({
-				arrows: round.arrows ?? round.scores.length ?? 0,
+				arrows: round.arrows || round.scores?.length || 0,
 				arrowsWithoutScore: round.arrowsWithoutScore || 0,
 				scores: round.scores,
 				roundScore: round.roundScore,

--- a/app/api/practices/[id]/route.ts
+++ b/app/api/practices/[id]/route.ts
@@ -99,7 +99,7 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
 			return {
 				practiceId: practiceId,
-				arrows: round.numberArrows || 0,
+				arrows: round.numberArrows || null,
 				arrowsWithoutScore: round.arrowsWithoutScore || null,
 				scores: round.scores || [],
 				arrowCoordinates: round.arrowCoordinates || Prisma.JsonNull,

--- a/app/api/stats/detailed/route.ts
+++ b/app/api/stats/detailed/route.ts
@@ -118,7 +118,7 @@ export async function GET(request: Request) {
 					const key = `${distanceLabel} - ${targetLabel}`;
 
 					// Include both arrows with score and arrowsWithoutScore
-					const scoredArrows = typeof end.arrows === 'number' ? end.arrows : (end.scores?.length ?? 0);
+					const scoredArrows = end.arrows || end.scores?.length || 0;
 					const arrows = scoredArrows + (typeof end.arrowsWithoutScore === 'number' ? end.arrowsWithoutScore : 0);
 					const score = typeof end.roundScore === 'number' ? end.roundScore : 0;
 

--- a/lib/achievements/checker.ts
+++ b/lib/achievements/checker.ts
@@ -64,7 +64,7 @@ export function calculateUserStats(practices: PracticeData[]): UserStats {
 		if (practice.ends && Array.isArray(practice.ends)) {
 			practiceArrows = practice.ends.reduce(
 				(sum: number, end: any) =>
-					sum + (end.arrows ?? end.scores?.length ?? 0) + (end.arrowsWithoutScore || 0),
+					sum + (end.arrows || end.scores?.length || 0) + (end.arrowsWithoutScore || 0),
 				0
 			);
 			stats.totalArrows += practiceArrows;
@@ -205,7 +205,7 @@ export function checkRequirement(
 					(p) =>
 						p.ends?.reduce(
 							(sum: number, end: any) =>
-								sum + (end.arrows ?? end.scores?.length ?? 0) + (end.arrowsWithoutScore || 0),
+								sum + (end.arrows || end.scores?.length || 0) + (end.arrowsWithoutScore || 0),
 							0
 						) || 0
 				),


### PR DESCRIPTION
## Summary
- **fix:** The previous arrow count fix used `??` (nullish coalescing) which doesn't trigger for `0` — only for `null`/`undefined`. Any practice edited via PATCH had `arrows: 0` stored (not null), so the fallback to `scores.length` never triggered. Switched to `||` which treats both `0` and `null` as falsy.
- **fix:** Added optional chaining (`end.scores?.length`) — without it, any end with a null scores array would crash the entire achievement check endpoint, returning a silent 500 to the client.
- **fix:** PATCH route now stores `null` instead of `0` when `numberArrows` is absent, matching the POST route.

## Test plan
- [x] All 224 tests pass
- [x] Type check passes
- [x] Lint passes (0 errors)
- [ ] Verify achievement unlocks after saving a new practice that crosses the 1000 arrow threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)