### PR TITLE
Release: security audit fixes and landing page updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,11 +88,13 @@ Bueboka implements the following security measures:
 - ✅ Password hashing with bcrypt
 - ✅ Session management with secure cookies
 - ✅ SQL injection protection (Prisma ORM)
-- ✅ Rate limiting on authentication endpoints
+- ✅ Rate limiting on authentication and API endpoints
 - ✅ Email verification for new accounts
-- ✅ CSRF protection
-- ✅ Secure password reset flow
-- ✅ Input validation on all API endpoints
+- ✅ OAuth state validation (CSRF protection)
+- ✅ Content Security Policy (CSP) headers
+- ✅ HSTS, X-Content-Type-Options, Referrer-Policy headers
+- ✅ Secure password reset flow with session revocation
+- ✅ Input validation on all API endpoints (Zod schemas)
 
 ## Disclosure Policy
 
@@ -115,4 +117,4 @@ If you have suggestions on how this process could be improved, please submit a p
 
 ---
 
-**Last Updated:** February 19, 2026
+**Last Updated:** June 5, 2026

--- a/app/api/competitions/[id]/route.ts
+++ b/app/api/competitions/[id]/route.ts
@@ -65,13 +65,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 		});
 	} catch (error) {
 		console.error('Error fetching competition:', error);
-		return NextResponse.json(
-			{
-				error: 'Failed to fetch competition',
-				details: error instanceof Error ? error.message : 'Unknown error',
-			},
-			{ status: 500 }
-		);
+		return NextResponse.json({ error: 'Failed to fetch competition' }, { status: 500 });
 	}
 }
 
@@ -202,13 +196,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 		return NextResponse.json({ competition });
 	} catch (error) {
 		console.error('Error updating competition:', error);
-		return NextResponse.json(
-			{
-				error: 'Failed to update competition',
-				details: error instanceof Error ? error.message : 'Unknown error',
-			},
-			{ status: 500 }
-		);
+		return NextResponse.json({ error: 'Failed to update competition' }, { status: 500 });
 	}
 }
 
@@ -252,12 +240,6 @@ export async function DELETE(request: Request, { params }: RouteParams) {
 		return new NextResponse(null, { status: 204 });
 	} catch (error) {
 		console.error('Error deleting competition:', error);
-		return NextResponse.json(
-			{
-				error: 'Failed to delete competition',
-				details: error instanceof Error ? error.message : 'Unknown error',
-			},
-			{ status: 500 }
-		);
+		return NextResponse.json({ error: 'Failed to delete competition' }, { status: 500 });
 	}
 }

--- a/app/api/competitions/route.ts
+++ b/app/api/competitions/route.ts
@@ -163,12 +163,6 @@ export async function POST(request: Request) {
 		return NextResponse.json({ competition }, { status: 201 });
 	} catch (error) {
 		console.error('Error creating competition:', error);
-		return NextResponse.json(
-			{
-				error: 'Failed to create competition',
-				details: error instanceof Error ? error.message : 'Unknown error',
-			},
-			{ status: 500 }
-		);
+		return NextResponse.json({ error: 'Failed to create competition' }, { status: 500 });
 	}
 }

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -2,6 +2,14 @@ import { NextResponse } from 'next/server';
 import { sendEmail } from '@/lib/email';
 import { getCurrentUser } from '@/lib/session';
 
+function escapeHtml(str: string): string {
+	return str
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
 export async function POST(request: Request) {
 	try {
 		const user = await getCurrentUser(request);
@@ -98,12 +106,12 @@ export async function POST(request: Request) {
 						
 						<div class="info-box">
 							<div class="info-label">Fra bruker:</div>
-							<div>${user.name || 'Ukjent navn'}</div>
+							<div>${escapeHtml(user.name || 'Ukjent navn')}</div>
 						</div>
 
 						<div class="info-box">
 							<div class="info-label">E-post:</div>
-							<div>${user.email}</div>
+							<div>${escapeHtml(user.email)}</div>
 						</div>
 
 						<div class="info-box">
@@ -112,7 +120,7 @@ export async function POST(request: Request) {
 						</div>
 
 						<div class="info-label" style="margin-top: 20px; margin-bottom: 10px;">Tilbakemelding:</div>
-						<div class="feedback-text">${feedback.trim()}</div>
+						<div class="feedback-text">${escapeHtml(feedback.trim())}</div>
 
 						<div class="footer">
 							<p>Mottatt ${new Date().toLocaleString('nb-NO', {
@@ -139,9 +147,14 @@ ${feedback.trim()}
 Mottatt: ${new Date().toLocaleString('nb-NO')}
 		`;
 
-		// Send email
+		const feedbackEmail = process.env.FEEDBACK_EMAIL;
+		if (!feedbackEmail) {
+			console.error('FEEDBACK_EMAIL environment variable is not set');
+			return NextResponse.json({ error: 'Failed to send feedback' }, { status: 500 });
+		}
+
 		await sendEmail({
-			to: 'haakon.rusas@pm.me',
+			to: feedbackEmail,
 			subject: `Tilbakemelding fra ${user.name || user.email} - ${stars}`,
 			html: emailHtml,
 			text: emailText,

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -155,7 +155,7 @@ Mottatt: ${new Date().toLocaleString('nb-NO')}
 
 		await sendEmail({
 			to: feedbackEmail,
-			subject: `Tilbakemelding fra ${user.name || user.email} - ${stars}`,
+			subject: `Tilbakemelding fra ${escapeHtml(user.name || user.email)} - ${stars}`,
 			html: emailHtml,
 			text: emailText,
 		});

--- a/app/api/practices/[id]/route.ts
+++ b/app/api/practices/[id]/route.ts
@@ -158,13 +158,8 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 			return NextResponse.json({ error: 'A practice with this data already exists' }, { status: 409 });
 		}
 
-		return NextResponse.json(
-			{
-				error: 'Failed to update practice',
-				details: error instanceof Error ? error.message : 'Unknown error',
-			},
-			{ status: 500 }
-		);
+		console.error('Error updating practice:', error);
+		return NextResponse.json({ error: 'Failed to update practice' }, { status: 500 });
 	}
 }
 

--- a/app/api/practices/route.ts
+++ b/app/api/practices/route.ts
@@ -133,13 +133,8 @@ export async function POST(request: NextRequest) {
 
 		return NextResponse.json({ practice }, { status: 201 });
 	} catch (error) {
-		return NextResponse.json(
-			{
-				error: 'Failed to create practice',
-				details: error instanceof Error ? error.message : 'Unknown error',
-			},
-			{ status: 500 }
-		);
+		console.error('Error creating practice:', error);
+		return NextResponse.json({ error: 'Failed to create practice' }, { status: 500 });
 	}
 }
 

--- a/app/api/sight-marks/[id]/results/route.ts
+++ b/app/api/sight-marks/[id]/results/route.ts
@@ -22,7 +22,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 		});
 
 		return NextResponse.json({ sightMarkResults: results });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark results API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -83,5 +86,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 		});
 
 		return NextResponse.json({ sightMarkResult: result }, { status: 201 });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark results API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }

--- a/app/api/sight-marks/[id]/route.ts
+++ b/app/api/sight-marks/[id]/route.ts
@@ -18,7 +18,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 		if (!sightMark) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
 		return NextResponse.json({ sightMark });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -67,7 +70,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 		});
 
 		return NextResponse.json({ sightMark: updated });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }
 
 export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -85,5 +91,8 @@ export async function DELETE(_request: NextRequest, { params }: { params: Promis
 		]);
 
 		return new NextResponse(null, { status: 204 });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }

--- a/app/api/sight-marks/results/[id]/route.ts
+++ b/app/api/sight-marks/results/[id]/route.ts
@@ -17,7 +17,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 		if (!result) return NextResponse.json({ error: 'Not found' }, { status: 404 });
 
 		return NextResponse.json({ sightMarkResult: result });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark result API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -71,7 +74,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 		const updated = await prisma.sightMarkResult.update({ where: { id }, data: updateData });
 		return NextResponse.json({ sightMarkResult: updated });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark result API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }
 
 export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -85,5 +91,8 @@ export async function DELETE(_request: NextRequest, { params }: { params: Promis
 
 		await prisma.sightMarkResult.delete({ where: { id } });
 		return new NextResponse(null, { status: 204 });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight mark result API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }

--- a/app/api/sight-marks/route.ts
+++ b/app/api/sight-marks/route.ts
@@ -18,7 +18,10 @@ export async function GET(request: NextRequest) {
 		});
 
 		return NextResponse.json({ sightMarks });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight marks API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }
 
 export async function POST(request: NextRequest) {
@@ -68,5 +71,8 @@ export async function POST(request: NextRequest) {
 		});
 
 		return NextResponse.json({ sightMark }, { status: 201 });
-	} catch (error) {}
+	} catch (error) {
+		console.error('Sight marks API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }

--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -138,7 +138,10 @@ export async function GET(request: Request) {
 				Vary: 'Cookie',
 			},
 		});
-	} catch (error) {}
+	} catch (error) {
+		console.error('Stats API error:', error);
+		return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+	}
 }
 
 function overallNumber(v: bigint | number | null | undefined) {

--- a/components/WhatsNewModal/WhatsNewModal.tsx
+++ b/components/WhatsNewModal/WhatsNewModal.tsx
@@ -11,6 +11,19 @@ import { IoMdTrendingUp } from 'react-icons/io';
 import { HiOutlineXMark } from 'react-icons/hi2';
 import { useTranslation } from '@/context/LanguageProvider';
 
+function SafeHtml({ text }: { text: string }) {
+	const parts = text.split(/(<strong>.*?<\/strong>)/g);
+	return (
+		<>
+			{parts.map((part, i) => {
+				const match = part.match(/^<strong>(.*)<\/strong>$/);
+				if (match) return <strong key={i}>{match[1]}</strong>;
+				return <React.Fragment key={i}>{part}</React.Fragment>;
+			})}
+		</>
+	);
+}
+
 interface WhatsNewModalProps {
 	open: boolean;
 	onClose: () => void;
@@ -80,21 +93,21 @@ export function WhatsNewModal({ open, onClose }: WhatsNewModalProps) {
 						<div className={styles.stepNumber}>1</div>
 						<div className={styles.stepText}>
 							<h4>{t['whatsNew.step1Title']}</h4>
-							<p dangerouslySetInnerHTML={{ __html: t['whatsNew.step1Text'] }} />
+							<p><SafeHtml text={t['whatsNew.step1Text']} /></p>
 						</div>
 					</div>
 					<div className={styles.stepItem}>
 						<div className={styles.stepNumber}>2</div>
 						<div className={styles.stepText}>
 							<h4>{t['whatsNew.step2Title']}</h4>
-							<p dangerouslySetInnerHTML={{ __html: t['whatsNew.step2Text'] }} />
+							<p><SafeHtml text={t['whatsNew.step2Text']} /></p>
 						</div>
 					</div>
 					<div className={styles.stepItem}>
 						<div className={styles.stepNumber}>3</div>
 						<div className={styles.stepText}>
 							<h4>{t['whatsNew.step3Title']}</h4>
-							<p dangerouslySetInnerHTML={{ __html: t['whatsNew.step3Text'] }} />
+							<p><SafeHtml text={t['whatsNew.step3Text']} /></p>
 						</div>
 					</div>
 				</div>

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,141 @@
+# Security Overview
+
+Summary of Bueboka's security posture, the measures in place, and best practices for contributors. For vulnerability reporting, see [SECURITY.md](../SECURITY.md).
+
+---
+
+## Authentication
+
+Auth is handled by [Better Auth](https://www.better-auth.com/) v1.6.14+ with the Prisma adapter.
+
+### Password policy
+
+- Minimum 8 characters
+- At least one uppercase letter
+- At least one number
+- These rules apply to signup only — login does not enforce complexity (to avoid locking out users with pre-existing passwords)
+
+### Email verification
+
+Email verification is **required** for new accounts. Users must verify before they can access the app. Verification emails are also re-sent on sign-in if the account is still unverified.
+
+### Session management
+
+| Setting | Value |
+|---|---|
+| Session lifetime | 7 days |
+| Update age | 24 hours |
+| Revoke on password reset | Yes |
+| Secure cookies | Production only (HTTPS) |
+
+When a user resets their password, all existing sessions are invalidated. This prevents an attacker from maintaining access after a compromised password is changed.
+
+### OAuth (Google)
+
+OAuth state validation is enabled (the default). The `@better-auth/expo` plugin provides an authorization proxy that sets the state cookie server-side, allowing mobile OAuth flows to work without disabling CSRF protection.
+
+---
+
+## Rate Limiting
+
+### Auth endpoints
+
+Better Auth's built-in rate limiter is configured at **10 requests per 15-minute window** per IP. This covers login, signup, password reset, and other auth-related endpoints.
+
+### API endpoints
+
+A Next.js middleware (`middleware.ts`) applies rate limiting to all `/api/*` routes at **60 requests per minute** per IP. The limiter uses an in-memory map with automatic cleanup when the entry count exceeds 10,000.
+
+**Shared IP considerations:** Users behind the same NAT (office, school, public WiFi) share a rate limit. The 60/min API limit is generous enough for normal multi-user scenarios, but the 10/15min auth limit could affect users on shared networks if multiple people are signing in simultaneously.
+
+---
+
+## HTTP Security Headers
+
+All production responses include the following headers (configured in `next.config.mjs`):
+
+| Header | Value | Purpose |
+|---|---|---|
+| `Content-Security-Policy` | See below | Prevents XSS and unwanted resource loading |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Enforces HTTPS |
+| `X-Content-Type-Options` | `nosniff` | Prevents MIME sniffing |
+| `X-Frame-Options` | `SAMEORIGIN` | Prevents clickjacking |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Controls referrer leakage |
+| `Permissions-Policy` | `geolocation=(), microphone=(), camera=()` | Disables unused browser features |
+
+### Content Security Policy
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.clarity.ms;
+style-src 'self' 'unsafe-inline';
+img-src 'self' data: blob: https://lh3.googleusercontent.com;
+font-src 'self';
+connect-src 'self' https://www.clarity.ms https://calculate-aim.azurewebsites.net;
+frame-ancestors 'none'
+```
+
+`unsafe-inline` and `unsafe-eval` are required for Next.js to function (it injects inline scripts). If you add a new third-party service (analytics, CDN, external API), you must update the CSP in `next.config.mjs` or the browser will silently block it. Check the browser console for `Content-Security-Policy` violations after adding new integrations.
+
+---
+
+## Input Validation & Output Encoding
+
+- All API inputs are validated with [Zod](https://zod.dev/) schemas
+- Database access uses Prisma ORM exclusively — no raw string concatenation in SQL (parameterized `$queryRaw` templates are used where raw SQL is needed)
+- User-controlled content in HTML emails is escaped with `escapeHtml()` to prevent injection
+- The `WhatsNewModal` uses a `SafeHtml` component that only renders `<strong>` tags, rejecting all other HTML
+
+---
+
+## Error Handling
+
+API error responses follow these rules:
+
+- **Never expose internal error details** — all `catch` blocks log the full error server-side with `console.error` and return a generic message to the client
+- **Always return a response** — no empty `catch` blocks; every error path returns an appropriate HTTP status code
+- **Use specific error messages for validation** — field-level validation errors are returned so the client can display helpful feedback, but server/database errors are always generic
+
+---
+
+## Environment Variables
+
+Sensitive configuration is stored in environment variables, never hardcoded in source code. The `.env` file is excluded from version control via `.gitignore`.
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `BETTER_AUTH_SECRET` | Yes | Session signing key |
+| `DATABASE_URL` | Yes | PostgreSQL connection string |
+| `GOOGLE_CLIENT_ID` | Yes | OAuth provider |
+| `GOOGLE_CLIENT_SECRET` | Yes | OAuth provider |
+| `RESEND_API_KEY` | Yes | Email delivery |
+| `FEEDBACK_EMAIL` | Yes | Recipient for user feedback submissions |
+
+**Never commit secrets.** If a secret is accidentally committed, rotate it immediately — removing it from the code is not enough since it remains in git history.
+
+---
+
+## Dependency Management
+
+- **Dependabot** is configured (`.github/dependabot.yml`) to check for npm updates weekly (Monday 06:00 Oslo time)
+- Run `npm audit` regularly — the project aims for zero high/critical vulnerabilities
+- Never run `npm update` — manually bump versions in `package.json` and run `npm install` (see CLAUDE.md)
+- Production source maps are disabled to prevent exposing source code
+
+---
+
+## Best Practices for Contributors
+
+1. **Validate at the boundary.** All user input must be validated with Zod schemas before touching the database. Trust Prisma for SQL safety, but validate types, ranges, and formats yourself.
+
+2. **Don't leak errors.** Log the full error, return a generic message. Never include `error.message` or stack traces in API responses.
+
+3. **Escape user content in HTML.** If you render user-controlled strings in HTML (emails, SSR), use `escapeHtml()` or the `SafeHtml` component. Never use `dangerouslySetInnerHTML` with anything that could contain user input.
+
+4. **Check ownership on every mutation.** Every PUT/PATCH/DELETE must verify that the authenticated user owns the resource. The pattern is: fetch the record, compare `userId` to the session user, return 404 if not matched (not 403 — to avoid revealing that the resource exists).
+
+5. **Keep the CSP updated.** When adding a new external service, add its domain to the appropriate CSP directive in `next.config.mjs`. Test in the browser console for violations.
+
+6. **Use environment variables for secrets.** No API keys, emails, URLs, or credentials hardcoded in source code. Add new variables to `.env` locally and to the hosting provider for production.
+
+7. **Rate limiting awareness.** Auth endpoints are aggressively rate-limited (10/15min). If you add a new auth-adjacent endpoint, consider whether it falls under Better Auth's rate limiter or needs separate protection.

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -51,8 +51,8 @@ export const auth = betterAuth({
 		},
 		resetPasswordTokenExpiresIn: 60 * 30, // 30 minutes
 		// You can enable this later if you want to sign out all devices after reset.
-		revokeSessionsOnPasswordReset: false,
-		requireEmailVerification: false,
+		revokeSessionsOnPasswordReset: true,
+		requireEmailVerification: true,
 	},
 	redirect: {
 		signIn: '/min-side',

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -80,7 +80,7 @@ export const auth = betterAuth({
 		updateAge: 60 * 60 * 24,
 	},
 	account: {
-		skipStateCookieCheck: true,
+		skipStateCookieCheck: false,
 	},
 	advanced: {
 		generateId: false,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -98,9 +98,9 @@ export const auth = betterAuth({
 	},
 	rateLimit: {
 		enabled: true,
-		maxRequests: 100,
-		windowMs: 60000, // 1 minute (60000ms)
-		message: 'Too many requests from this IP, please try again after a minute',
+		maxRequests: 10,
+		windowMs: 900000, // 15 minutes
+		message: 'Too many requests from this IP, please try again later',
 	},
 });
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -50,7 +50,6 @@ export const auth = betterAuth({
 			void sendEmail({ to: user.email, ...email });
 		},
 		resetPasswordTokenExpiresIn: 60 * 30, // 30 minutes
-		// You can enable this later if you want to sign out all devices after reset.
 		revokeSessionsOnPasswordReset: true,
 		requireEmailVerification: true,
 	},
@@ -78,9 +77,6 @@ export const auth = betterAuth({
 	session: {
 		expiresIn: 60 * 60 * 24 * 7,
 		updateAge: 60 * 60 * 24,
-	},
-	account: {
-		skipStateCookieCheck: false,
 	},
 	advanced: {
 		generateId: false,

--- a/lib/validations/authValidation.ts
+++ b/lib/validations/authValidation.ts
@@ -35,13 +35,26 @@ export function validateEmail(email: string | null | undefined): string | undefi
  * @param minLength - Minimum required length (default: 8)
  * @returns Error message if invalid, undefined if valid
  */
-export function validatePassword(password: string | null | undefined, minLength: number = 8): string | undefined {
+export function validatePassword(
+	password: string | null | undefined,
+	minLength: number = 8,
+	requireComplexity: boolean = false
+): string | undefined {
 	if (!password || password.trim() === '') {
 		return 'Passord mangler';
 	}
 
 	if (password.length < minLength) {
 		return `Passord må være minst ${minLength} tegn`;
+	}
+
+	if (requireComplexity) {
+		if (!/[A-Z]/.test(password)) {
+			return 'Passord må inneholde minst én stor bokstav';
+		}
+		if (!/[0-9]/.test(password)) {
+			return 'Passord må inneholde minst ett tall';
+		}
 	}
 
 	return undefined;
@@ -98,7 +111,7 @@ export function validateSignUpForm(
 	const emailError = validateEmail(email);
 	if (emailError) errors.email = emailError;
 
-	const passwordError = validatePassword(password, 8); // Signup requires 8 chars
+	const passwordError = validatePassword(password, 8, true);
 	if (passwordError) errors.password = passwordError;
 
 	return errors;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+const windowMs = 60_000;
+const maxRequests = 60;
+
+const hits = new Map<string, { count: number; resetAt: number }>();
+
+function getClientIp(request: NextRequest): string {
+	return (
+		request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+		request.headers.get('x-real-ip') ||
+		'unknown'
+	);
+}
+
+export function middleware(request: NextRequest) {
+	const ip = getClientIp(request);
+	const now = Date.now();
+	const entry = hits.get(ip);
+
+	if (!entry || entry.resetAt <= now) {
+		hits.set(ip, { count: 1, resetAt: now + windowMs });
+		return NextResponse.next();
+	}
+
+	entry.count++;
+	if (entry.count > maxRequests) {
+		return NextResponse.json(
+			{ error: 'Too many requests, please try again later' },
+			{ status: 429 }
+		);
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	matcher: '/api/:path*',
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,6 +5,7 @@ const windowMs = 60_000;
 const maxRequests = 60;
 
 const hits = new Map<string, { count: number; resetAt: number }>();
+const MAX_ENTRIES = 10_000;
 
 function getClientIp(request: NextRequest): string {
 	return (
@@ -20,6 +21,11 @@ export function middleware(request: NextRequest) {
 	const entry = hits.get(ip);
 
 	if (!entry || entry.resetAt <= now) {
+		if (hits.size >= MAX_ENTRIES) {
+			for (const [key, val] of hits) {
+				if (val.resetAt <= now) hits.delete(key);
+			}
+		}
 		hits.set(ip, { count: 1, resetAt: now + windowMs });
 		return NextResponse.next();
 	}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,8 +4,7 @@ const nextConfig = {
 	compress: true,
 	poweredByHeader: false,
 
-	// Enable source maps for production (improves debugging and Lighthouse Best Practices score)
-	productionBrowserSourceMaps: true,
+	productionBrowserSourceMaps: false,
 
 	// Bypass Next.js image optimization — Netlify's /_next/image endpoint returns 404
 	images: {
@@ -64,6 +63,34 @@ const nextConfig = {
 					{
 						key: 'X-Frame-Options',
 						value: 'SAMEORIGIN',
+					},
+					{
+						key: 'X-Content-Type-Options',
+						value: 'nosniff',
+					},
+					{
+						key: 'Strict-Transport-Security',
+						value: 'max-age=31536000; includeSubDomains',
+					},
+					{
+						key: 'Referrer-Policy',
+						value: 'strict-origin-when-cross-origin',
+					},
+					{
+						key: 'Permissions-Policy',
+						value: 'geolocation=(), microphone=(), camera=()',
+					},
+					{
+						key: 'Content-Security-Policy',
+						value: [
+							"default-src 'self'",
+							"script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.clarity.ms",
+							"style-src 'self' 'unsafe-inline'",
+							"img-src 'self' data: blob: https://lh3.googleusercontent.com",
+							"font-src 'self'",
+							"connect-src 'self' https://www.clarity.ms https://calculate-aim.azurewebsites.net",
+							"frame-ancestors 'none'",
+						].join('; '),
 					},
 				],
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,14 @@
 			"name": "bueboka-web",
 			"version": "2.1.0",
 			"dependencies": {
-				"@better-auth/expo": "^1.5.5",
+				"@better-auth/expo": "^1.6.14",
 				"@microsoft/clarity": "^1.0.2",
 				"@next/eslint-plugin-next": "^16.2.7",
 				"@prisma/adapter-pg": "^7.8.0",
 				"@prisma/client": "^7.8.0",
 				"@prisma/extension-accelerate": "^3.0.1",
 				"bcrypt": "^6.0.0",
-				"better-auth": "^1.5.5",
+				"better-auth": "^1.6.14",
 				"dotenv": "^17.4.2",
 				"html-to-image": "^1.11.13",
 				"motion": "^12.40.0",
@@ -624,38 +624,43 @@
 			"license": "MIT"
 		},
 		"node_modules/@better-auth/core": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.5.5.tgz",
-			"integrity": "sha512-1oR/2jAp821Dcf67kQYHUoyNcdc1TcShfw4QMK0YTVntuRES5mUOyvEJql5T6eIuLfaqaN4LOF78l0FtF66HXA==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.14.tgz",
+			"integrity": "sha512-12cA7tnR4Wyb3nLpPmeq/Id7QNB+4OhjbzuX7sIhqglgXGjyT5iiNpe2lx/8FF532sHC450Yx1850salCYbkzw==",
 			"license": "MIT",
 			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.39.0",
 				"@standard-schema/spec": "^1.1.0",
 				"zod": "^4.3.6"
 			},
 			"peerDependencies": {
-				"@better-auth/utils": "0.3.1",
+				"@better-auth/utils": "0.4.1",
 				"@better-fetch/fetch": "1.1.21",
 				"@cloudflare/workers-types": ">=4",
-				"better-call": "1.3.2",
+				"@opentelemetry/api": "^1.9.0",
+				"better-call": "1.3.5",
 				"jose": "^6.1.0",
-				"kysely": "^0.28.5",
+				"kysely": "^0.28.5 || ^0.29.0",
 				"nanostores": "^1.0.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
 					"optional": true
+				},
+				"@opentelemetry/api": {
+					"optional": true
 				}
 			}
 		},
 		"node_modules/@better-auth/drizzle-adapter": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.5.5.tgz",
-			"integrity": "sha512-HAi9xAP40oDt48QZeYBFTcmg3vt1Jik90GwoRIfangd7VGbxesIIDBJSnvwMbZ52GBIc6+V4FRw9lasNiNrPfw==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.14.tgz",
+			"integrity": "sha512-lYs1jDudriKYMXNcLFLAvEvOEKbeKBFdDciG4H8qZhV+3+yghGC3f/H5qtgTDc8mGBPV+2tEvVgYqReurOSmNw==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "1.5.5",
-				"@better-auth/utils": "^0.3.0",
-				"drizzle-orm": ">=0.41.0"
+				"@better-auth/core": "^1.6.14",
+				"@better-auth/utils": "0.4.1",
+				"drizzle-orm": "^0.45.2"
 			},
 			"peerDependenciesMeta": {
 				"drizzle-orm": {
@@ -664,18 +669,18 @@
 			}
 		},
 		"node_modules/@better-auth/expo": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/expo/-/expo-1.5.5.tgz",
-			"integrity": "sha512-viaMqxnxVYQyDAzPAWqsVDwE0REI2t/2lOUzqYwK1wP9NOTA/DlvydNPgNrsl3iboes3FlyktDOb9XdeGAjzEQ==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/expo/-/expo-1.6.14.tgz",
+			"integrity": "sha512-1QuBCJlvr91Dr3HBXSULbVSvAUpABrHUruvYXUKqGPwzyFEpWQIL+SpWcPxwt0oBq75ghnsU1X52EBym72SllA==",
 			"license": "MIT",
 			"dependencies": {
 				"@better-fetch/fetch": "1.1.21",
-				"better-call": "1.3.2",
+				"better-call": "1.3.5",
 				"zod": "^4.3.6"
 			},
 			"peerDependencies": {
-				"@better-auth/core": "1.5.5",
-				"better-auth": "1.5.5",
+				"@better-auth/core": "^1.6.14",
+				"better-auth": "^1.6.14",
 				"expo-constants": ">=17.0.0",
 				"expo-linking": ">=7.0.0",
 				"expo-network": ">=8.0.7",
@@ -697,45 +702,55 @@
 			}
 		},
 		"node_modules/@better-auth/kysely-adapter": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.5.5.tgz",
-			"integrity": "sha512-LmHffIVnqbfsxcxckMOoE8MwibWrbVFch+kwPKJ5OFDFv6lin75ufN7ZZ7twH0IMPLT/FcgzaRjP8jRrXRef9g==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.14.tgz",
+			"integrity": "sha512-A2+381gYADuZpgd98XQ39bnxLzbT03wnnDmSQIXp7XcE3hF093mGMk6rxlAhENVHH7JL2B0Tv2la2o6n+6ppyQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "1.5.5",
-				"@better-auth/utils": "^0.3.0",
-				"kysely": "^0.27.0 || ^0.28.0"
+				"@better-auth/core": "^1.6.14",
+				"@better-auth/utils": "0.4.1",
+				"kysely": "^0.28.17 || ^0.29.0"
+			},
+			"peerDependenciesMeta": {
+				"kysely": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@better-auth/memory-adapter": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.5.5.tgz",
-			"integrity": "sha512-4X0j1/2L+nsgmObjmy9xEGUFWUv38Qjthp558fwS3DAp6ueWWyCaxaD6VJZ7m5qPNMrsBStO5WGP8CmJTEWm7g==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.14.tgz",
+			"integrity": "sha512-frtBTozi8qsBlypxp33dkiIZT2IOMvix3oh2qTTcBkK11ISsRSTUUadl7DbwXri2AEoooShsH6PSAput920J3Q==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "1.5.5",
-				"@better-auth/utils": "^0.3.0"
+				"@better-auth/core": "^1.6.14",
+				"@better-auth/utils": "0.4.1"
 			}
 		},
 		"node_modules/@better-auth/mongo-adapter": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.5.5.tgz",
-			"integrity": "sha512-P1J9ljL5X5k740I8Rx1esPWNgWYPdJR5hf2CY7BwDSrQFPUHuzeCg0YhtEEP55niNateTXhBqGAcy0fVOeamZg==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.14.tgz",
+			"integrity": "sha512-meaZx712k9c0Cl6urwYZRNa3mAy3/leaYiSNt+hVaCOEPlgTDxzmYMNACvTTYXgh4eCpDVf5G7ZMEYBtejKQdw==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "1.5.5",
-				"@better-auth/utils": "^0.3.0",
+				"@better-auth/core": "^1.6.14",
+				"@better-auth/utils": "0.4.1",
 				"mongodb": "^6.0.0 || ^7.0.0"
+			},
+			"peerDependenciesMeta": {
+				"mongodb": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@better-auth/prisma-adapter": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.5.5.tgz",
-			"integrity": "sha512-CliDd78CXHzzwQIXhCdwGr5Ml53i6JdCHWV7PYwTIJz9EAm6qb2RVBdpP3nqEfNjINGM22A6gfleCgCdZkTIZg==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.14.tgz",
+			"integrity": "sha512-9b9wSqhCthMmOYo0QdX+N/cOv+fNck/JE5CZQuuWwEJl5QeoYhCZesXjts5VfLAPMIf6vKw3QNBrn0SVMXXi2Q==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@better-auth/core": "1.5.5",
-				"@better-auth/utils": "^0.3.0",
+				"@better-auth/core": "^1.6.14",
+				"@better-auth/utils": "0.4.1",
 				"@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
 				"prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
 			},
@@ -749,23 +764,24 @@
 			}
 		},
 		"node_modules/@better-auth/telemetry": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.5.5.tgz",
-			"integrity": "sha512-1+lklxArn4IMHuU503RcPdXrSG2tlXt4jnGG3omolmspQ7tktg/Y9XO/yAkYDurtvMn1xJ8X1Ov01Ji/r5s9BQ==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.14.tgz",
+			"integrity": "sha512-ALi3cEx5eyrFY+TeAdhc1uq8FqJyGvzgvIo7GQZOqGqLZxHY9nte44WN++jBFGJJbsW3e4cgLj8dQK291s6wWQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@better-auth/utils": "0.3.1",
-				"@better-fetch/fetch": "1.1.21"
-			},
 			"peerDependencies": {
-				"@better-auth/core": "1.5.5"
+				"@better-auth/core": "^1.6.14",
+				"@better-auth/utils": "0.4.1",
+				"@better-fetch/fetch": "1.1.21"
 			}
 		},
 		"node_modules/@better-auth/utils": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.1.tgz",
-			"integrity": "sha512-+CGp4UmZSUrHHnpHhLPYu6cV+wSUSvVbZbNykxhUDocpVNTo9uFFxw/NqJlh1iC4wQ9HKKWGCKuZ5wUgS0v6Kg==",
-			"license": "MIT"
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.1.tgz",
+			"integrity": "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==",
+			"license": "MIT",
+			"dependencies": {
+				"@noble/hashes": "^2.0.1"
+			}
 		},
 		"node_modules/@better-fetch/fetch": {
 			"version": "1.1.21",
@@ -1291,14 +1307,14 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
 			"integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@electric-sql/pglite-socket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
 			"integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"pglite-server": "dist/scripts/server.js"
@@ -1311,7 +1327,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
 			"integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"@electric-sql/pglite": "0.4.1"
@@ -1823,6 +1839,7 @@
 			"version": "0.23.5",
 			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
 			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^3.0.5",
@@ -1837,15 +1854,17 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -1858,6 +1877,7 @@
 			"version": "10.2.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
 			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"brace-expansion": "^5.0.5"
@@ -1873,6 +1893,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
 			"integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/core": "^1.2.1"
@@ -1885,6 +1906,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
 			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
@@ -1897,6 +1919,7 @@
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
 			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
@@ -1906,6 +1929,7 @@
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
 			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/core": "^1.2.1",
@@ -1919,7 +1943,7 @@
 			"version": "1.19.11",
 			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
 			"integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.14.1"
@@ -1932,6 +1956,7 @@
 			"version": "0.19.1",
 			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
 			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18.0"
@@ -1941,6 +1966,7 @@
 			"version": "0.16.6",
 			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
 			"integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@humanfs/core": "^0.19.1",
@@ -1954,6 +1980,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
 			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18"
@@ -1967,6 +1994,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.22"
@@ -1980,6 +2008,7 @@
 			"version": "0.4.2",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
 			"integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.18"
@@ -3054,7 +3083,7 @@
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
 			"integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@microsoft/clarity": {
@@ -3062,16 +3091,6 @@
 			"resolved": "https://registry.npmjs.org/@microsoft/clarity/-/clarity-1.0.2.tgz",
 			"integrity": "sha512-9EZYROFpJxEGmQpHvUFqvD3ZJ7QQSqnibYSWmS+1xusoZfG1QQ1/Al9yVBBc11DWMbJrs1pe1hLT273it/skJg==",
 			"license": "MIT"
-		},
-		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.8.tgz",
-			"integrity": "sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"sparse-bitfield": "^3.0.3"
-			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
 			"version": "0.2.12",
@@ -3310,6 +3329,15 @@
 				"node": ">=12.4.0"
 			}
 		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3389,7 +3417,7 @@
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
 			"integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"c12": "3.3.4",
@@ -3408,7 +3436,7 @@
 			"version": "0.24.3",
 			"resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
 			"integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"@electric-sql/pglite": "0.4.1",
@@ -3443,7 +3471,7 @@
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
 			"integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
-			"devOptional": true,
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -3457,14 +3485,14 @@
 			"version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
 			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
 			"integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
 			"integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prisma/debug": "7.8.0"
@@ -3485,7 +3513,7 @@
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
 			"integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prisma/debug": "7.8.0",
@@ -3497,7 +3525,7 @@
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
 			"integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prisma/debug": "7.8.0"
@@ -3507,7 +3535,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
 			"integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prisma/debug": "7.2.0"
@@ -3517,21 +3545,21 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
 			"integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/query-plan-executor": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
 			"integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/streams-local": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
 			"integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"ajv": "^8.12.0",
@@ -3548,7 +3576,7 @@
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -3565,7 +3593,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
 			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -3578,14 +3606,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@prisma/studio-core": {
 			"version": "0.27.3",
 			"resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
 			"integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@radix-ui/react-toggle": "1.1.10",
@@ -3605,14 +3633,14 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
 			"integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@radix-ui/react-compose-refs": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
 			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -3628,7 +3656,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
 			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@radix-ui/react-slot": "1.2.3"
@@ -3652,7 +3680,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
 			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@radix-ui/react-compose-refs": "1.1.2"
@@ -3671,7 +3699,7 @@
 			"version": "1.1.10",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
 			"integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@radix-ui/primitive": "1.1.3",
@@ -3697,7 +3725,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
 			"integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@radix-ui/react-use-effect-event": "0.0.2",
@@ -3717,7 +3745,7 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
 			"integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@radix-ui/react-use-layout-effect": "1.1.1"
@@ -3736,7 +3764,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
 			"integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "*",
@@ -4158,12 +4186,14 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
 			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
@@ -4220,6 +4250,7 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/json5": {
@@ -4253,7 +4284,7 @@
 			"version": "19.2.16",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
 			"integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -4263,7 +4294,7 @@
 			"version": "19.2.3",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
@@ -4288,23 +4319,6 @@
 			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
 			"integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
 			"license": "MIT"
-		},
-		"node_modules/@types/webidl-conversions": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-			"integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-			"license": "MIT",
-			"peer": true
-		},
-		"node_modules/@types/whatwg-url": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-			"integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/webidl-conversions": "*"
-			}
 		},
 		"node_modules/@types/yargs": {
 			"version": "17.0.35",
@@ -4870,6 +4884,7 @@
 			"version": "8.16.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
 			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -4882,6 +4897,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4901,6 +4917,7 @@
 			"version": "6.14.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
 			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -5193,7 +5210,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
 			"integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6.0.0"
@@ -5352,26 +5369,26 @@
 			}
 		},
 		"node_modules/better-auth": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.5.5.tgz",
-			"integrity": "sha512-GpVPaV1eqr3mOovKfghJXXk6QvlcVeFbS3z+n+FPDid5rK/2PchnDtiaVCzWyXA9jH2KkirOfl+JhAUvnja0Eg==",
+			"version": "1.6.14",
+			"resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.14.tgz",
+			"integrity": "sha512-c0/DvTQGDpgfj1knekCpQrg6PSWGDtfAtP7Ou6FkAhoE3RNnnIxLB5qKj6tRg53a1xsq93G6T68cNxrUZ7ZVmw==",
 			"license": "MIT",
 			"dependencies": {
-				"@better-auth/core": "1.5.5",
-				"@better-auth/drizzle-adapter": "1.5.5",
-				"@better-auth/kysely-adapter": "1.5.5",
-				"@better-auth/memory-adapter": "1.5.5",
-				"@better-auth/mongo-adapter": "1.5.5",
-				"@better-auth/prisma-adapter": "1.5.5",
-				"@better-auth/telemetry": "1.5.5",
-				"@better-auth/utils": "0.3.1",
+				"@better-auth/core": "1.6.14",
+				"@better-auth/drizzle-adapter": "1.6.14",
+				"@better-auth/kysely-adapter": "1.6.14",
+				"@better-auth/memory-adapter": "1.6.14",
+				"@better-auth/mongo-adapter": "1.6.14",
+				"@better-auth/prisma-adapter": "1.6.14",
+				"@better-auth/telemetry": "1.6.14",
+				"@better-auth/utils": "0.4.1",
 				"@better-fetch/fetch": "1.1.21",
 				"@noble/ciphers": "^2.1.1",
 				"@noble/hashes": "^2.0.1",
-				"better-call": "1.3.2",
+				"better-call": "1.3.5",
 				"defu": "^6.1.4",
 				"jose": "^6.1.3",
-				"kysely": "^0.28.11",
+				"kysely": "^0.28.17 || ^0.29.0",
 				"nanostores": "^1.1.1",
 				"zod": "^4.3.6"
 			},
@@ -5383,7 +5400,7 @@
 				"@tanstack/solid-start": "^1.0.0",
 				"better-sqlite3": "^12.0.0",
 				"drizzle-kit": ">=0.31.4",
-				"drizzle-orm": ">=0.41.0",
+				"drizzle-orm": "^0.45.2",
 				"mongodb": "^6.0.0 || ^7.0.0",
 				"mysql2": "^3.0.0",
 				"next": "^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -5457,12 +5474,12 @@
 			}
 		},
 		"node_modules/better-call": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.2.tgz",
-			"integrity": "sha512-4cZIfrerDsNTn3cm+MhLbUePN0gdwkhSXEuG7r/zuQ8c/H7iU0/jSK5TD3FW7U0MgKHce/8jGpPYNO4Ve+4NBw==",
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.5.tgz",
+			"integrity": "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==",
 			"license": "MIT",
 			"dependencies": {
-				"@better-auth/utils": "^0.3.1",
+				"@better-auth/utils": "^0.4.0",
 				"@better-fetch/fetch": "^1.1.21",
 				"rou3": "^0.7.12",
 				"set-cookie-parser": "^3.0.1"
@@ -5480,13 +5497,13 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.0.tgz",
 			"integrity": "sha512-NHwGDGVbRlWDOce3CwcfGIrcNR9zY37ut3SVwQVfv57DZdVhxjhA4mfaHN1n8QwWnRAR4iErpW1X/eaiaUaFYg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5550,16 +5567,6 @@
 				"node-int64": "^0.4.0"
 			}
 		},
-		"node_modules/bson": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-			"integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": ">=20.19.0"
-			}
-		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5571,7 +5578,7 @@
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
 			"integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^5.0.0",
@@ -5717,7 +5724,7 @@
 			"version": "4.5.1",
 			"resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
 			"integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@kurkle/color": "^0.3.0"
@@ -5730,7 +5737,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
 			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"readdirp": "^5.0.0"
@@ -5918,7 +5925,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
 			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/conventional-changelog-angular": {
@@ -6020,6 +6027,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -6055,7 +6063,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/d3-array": {
@@ -6303,6 +6311,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/deepmerge": {
@@ -6319,7 +6328,7 @@
 			"version": "7.1.5",
 			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
 			"integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=16.0.0"
@@ -6371,7 +6380,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
 			"integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=0.10"
@@ -6391,7 +6400,7 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
 			"integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/detect-libc": {
@@ -6485,7 +6494,7 @@
 			"version": "3.20.0",
 			"resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
 			"integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
@@ -6523,7 +6532,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
 			"integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -6806,6 +6815,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -6818,6 +6828,7 @@
 			"version": "10.4.1",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
 			"integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
@@ -7206,6 +7217,7 @@
 			"version": "9.1.2",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
 			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"@types/esrecurse": "^4.3.1",
@@ -7236,15 +7248,17 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -7257,6 +7271,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
 			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
@@ -7269,6 +7284,7 @@
 			"version": "10.2.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
 			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
@@ -7284,6 +7300,7 @@
 			"version": "11.2.0",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
 			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"acorn": "^8.16.0",
@@ -7301,6 +7318,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
 			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
@@ -7327,6 +7345,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
 			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"estraverse": "^5.1.0"
@@ -7339,6 +7358,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"estraverse": "^5.2.0"
@@ -7351,6 +7371,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=4.0"
@@ -7360,6 +7381,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -7434,14 +7456,14 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
 			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-check": {
 			"version": "3.23.2",
 			"resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
 			"integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -7464,6 +7486,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-diff": {
@@ -7505,12 +7528,14 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-sha256": {
@@ -7520,10 +7545,10 @@
 			"license": "Unlicense"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"devOptional": true,
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -7559,6 +7584,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
 			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"flat-cache": "^4.0.0"
@@ -7583,6 +7609,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"locate-path": "^6.0.0",
@@ -7599,6 +7626,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
 			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"flatted": "^3.2.9",
@@ -7609,9 +7637,10 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-			"integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/for-each": {
@@ -7634,7 +7663,7 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
 			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
@@ -7741,7 +7770,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
 			"integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-property": "^1.0.2"
@@ -7829,7 +7858,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
 			"integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/get-proto": {
@@ -7894,7 +7923,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
 			"integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"giget": "dist/cli.mjs"
@@ -7943,6 +7972,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.3"
@@ -8027,21 +8057,21 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/grammex": {
 			"version": "3.1.12",
 			"resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
 			"integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/graphmatch": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
 			"integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/has-bigints": {
@@ -8153,10 +8183,10 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.15",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-			"integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
-			"devOptional": true,
+			"version": "4.12.23",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+			"integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -8206,7 +8236,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
 			"integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/https-proxy-agent": {
@@ -8253,7 +8283,7 @@
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
 			"integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8270,6 +8300,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -8336,6 +8367,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -8719,7 +8751,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
 			"integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/is-regex": {
@@ -8891,6 +8923,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -9671,7 +9704,7 @@
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
 			"integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
@@ -9773,6 +9806,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-parse-even-better-errors": {
@@ -9786,12 +9820,14 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/json5": {
@@ -9827,15 +9863,16 @@
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
 		},
 		"node_modules/kysely": {
-			"version": "0.28.11",
-			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.11.tgz",
-			"integrity": "sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==",
+			"version": "0.28.17",
+			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+			"integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.0.0"
@@ -9875,6 +9912,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
@@ -9895,6 +9933,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-locate": "^5.0.0"
@@ -9910,7 +9949,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/loose-envify": {
@@ -9940,7 +9979,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.3.tgz",
 			"integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"bun": ">=1.0.0",
@@ -9997,13 +10036,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/memory-pager": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/meow": {
 			"version": "13.2.0",
@@ -10100,67 +10132,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/mongodb": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz",
-			"integrity": "sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@mongodb-js/saslprep": "^1.3.0",
-				"bson": "^7.1.1",
-				"mongodb-connection-string-url": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			},
-			"peerDependencies": {
-				"@aws-sdk/credential-providers": "^3.806.0",
-				"@mongodb-js/zstd": "^7.0.0",
-				"gcp-metadata": "^7.0.1",
-				"kerberos": "^7.0.0",
-				"mongodb-client-encryption": ">=7.0.0 <7.1.0",
-				"snappy": "^7.3.2",
-				"socks": "^2.8.6"
-			},
-			"peerDependenciesMeta": {
-				"@aws-sdk/credential-providers": {
-					"optional": true
-				},
-				"@mongodb-js/zstd": {
-					"optional": true
-				},
-				"gcp-metadata": {
-					"optional": true
-				},
-				"kerberos": {
-					"optional": true
-				},
-				"mongodb-client-encryption": {
-					"optional": true
-				},
-				"snappy": {
-					"optional": true
-				},
-				"socks": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/mongodb-connection-string-url": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-			"integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
-			"license": "Apache-2.0",
-			"peer": true,
-			"dependencies": {
-				"@types/whatwg-url": "^13.0.0",
-				"whatwg-url": "^14.1.0"
-			},
-			"engines": {
-				"node": ">=20.19.0"
-			}
-		},
 		"node_modules/motion": {
 			"version": "12.40.0",
 			"resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
@@ -10212,7 +10183,7 @@
 			"version": "3.15.3",
 			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
 			"integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"aws-ssl-profiles": "^1.1.1",
@@ -10233,7 +10204,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
 			"integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lru.min": "^1.1.0"
@@ -10348,34 +10319,6 @@
 				"sass": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/next/node_modules/postcss": {
-			"version": "8.4.31",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"nanoid": "^3.3.6",
-				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
 			}
 		},
 		"node_modules/node-addon-api": {
@@ -10598,7 +10541,7 @@
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
 			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/once": {
@@ -10631,6 +10574,7 @@
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"deep-is": "^0.1.3",
@@ -10666,6 +10610,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
@@ -10681,6 +10626,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"p-limit": "^3.0.2"
@@ -10758,6 +10704,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -10777,6 +10724,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -10817,14 +10765,14 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
 			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/perfect-debounce": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
 			"integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pg": {
@@ -10923,9 +10871,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -11017,7 +10965,7 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
 			"integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"confbox": "^0.2.4",
@@ -11041,11 +10989,39 @@
 			"integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
 			"license": "MIT-0"
 		},
+		"node_modules/postcss": {
+			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.6",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.2"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
 		"node_modules/postgres": {
 			"version": "3.4.7",
 			"resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
 			"integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Unlicense",
 			"engines": {
 				"node": ">=12"
@@ -11098,6 +11074,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8.0"
@@ -11165,7 +11142,7 @@
 			"version": "7.8.0",
 			"resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
 			"integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
-			"devOptional": true,
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -11211,7 +11188,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
 			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -11223,13 +11200,14 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -11239,7 +11217,7 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
 			"integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-			"devOptional": true,
+			"dev": true,
 			"funding": [
 				{
 					"type": "individual",
@@ -11276,7 +11254,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
 			"integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"defu": "^6.1.6",
@@ -11317,6 +11295,7 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/react-is-18": {
@@ -11362,7 +11341,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
 			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 20.19.0"
@@ -11479,7 +11458,7 @@
 			"version": "2.33.4",
 			"resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
 			"integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/remeda"
@@ -11499,7 +11478,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -11587,7 +11566,7 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -11698,7 +11677,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/saxes": {
@@ -11736,12 +11715,12 @@
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
 			"integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-			"devOptional": true
+			"dev": true
 		},
 		"node_modules/set-cookie-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.0.1.tgz",
-			"integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+			"integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
 			"license": "MIT"
 		},
 		"node_modules/set-function-length": {
@@ -11842,6 +11821,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -11854,6 +11834,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11939,7 +11920,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -11988,16 +11969,6 @@
 				"source-map": "^0.6.0"
 			}
 		},
-		"node_modules/sparse-bitfield": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-			"integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"memory-pager": "^1.0.2"
-			}
-		},
 		"node_modules/split2": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -12018,7 +11989,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
 			"integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -12068,7 +12039,7 @@
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
 			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/stop-iteration-iterator": {
@@ -12544,9 +12515,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -12611,6 +12582,7 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
 			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"punycode": "^2.3.1"
@@ -12673,6 +12645,7 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
@@ -12786,6 +12759,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -12913,6 +12887,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
@@ -12946,7 +12921,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
 			"integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"typescript": ">=5"
@@ -13006,6 +12981,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
 			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -13052,6 +13028,7 @@
 			"version": "14.2.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
 			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tr46": "^5.1.0",
@@ -13065,6 +13042,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -13169,6 +13147,7 @@
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -13433,6 +13412,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -13445,7 +13425,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
 			"integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"grammex": "^3.1.11",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
 		"prisma:push": "prisma db push"
 	},
 	"dependencies": {
-		"@better-auth/expo": "^1.5.5",
+		"@better-auth/expo": "^1.6.14",
 		"@microsoft/clarity": "^1.0.2",
 		"@next/eslint-plugin-next": "^16.2.7",
 		"@prisma/adapter-pg": "^7.8.0",
 		"@prisma/client": "^7.8.0",
 		"@prisma/extension-accelerate": "^3.0.1",
 		"bcrypt": "^6.0.0",
-		"better-auth": "^1.5.5",
+		"better-auth": "^1.6.14",
 		"dotenv": "^17.4.2",
 		"html-to-image": "^1.11.13",
 		"motion": "^12.40.0",


### PR DESCRIPTION
## Summary

- **Security audit fixes** — resolve critical OAuth CSRF vulnerability, upgrade better-auth to 1.6.14, add security headers (CSP, HSTS, X-Content-Type-Options), fix error handling across all API routes, add rate limiting middleware, enable email verification and session revocation on password reset, add Dependabot
- **Landing page updates** — convert screenshots to WebP format and fix accessibility issues
- **Cleanup** — remove app version check system

### Breaking changes
- New `FEEDBACK_EMAIL` env variable required in production
- Signup now requires password with uppercase letter + number
- Email verification required for new accounts
- Auth rate limit reduced to 10 requests per 15 minutes

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 224 tests pass
- [x] `npm run build` succeeds
- [ ] Verify OAuth login (Google) works from web and Expo
- [ ] Verify `FEEDBACK_EMAIL` is set in production env
- [ ] Check security headers after deploy (securityheaders.com)

🤖 Generated with [Claude Code](https://claude.com/claude-code)